### PR TITLE
Dev3

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,18 @@ Monitor your workflows. Find by `STR_LABEL` or `WF_ID` (UUID). Wildcard search (
 $ caper list [WF_ID or STR_LABEL]
 ```
 
+## Output directory organizer
+
+Cromwell's raw outputs are not organized. PIP install `croo`. Please read through `croo`'s [README](https://github.com/ENCODE-DCC/croo).
+```bash
+$ pip install croo
+```
+
+Use `croo` to organize outputs. For `METADATA_JSON`, find a `metadata.json` for your workflow in Caper's output directory. It is stored on `[CAPER_OUT_DIR]/[WDL_NAME]/[WF_ID]/metadata.json`. You need an [output definition JSON file](https://github.com/ENCODE-DCC/croo#output-definition-json-file) for your WDL. Find [examples](https://github.com/ENCODE-DCC/croo/tree/master/examples) for ENCODE ATAC/ChIP-seq pipelines. 
+```bash
+$ croo [METADATA_JSON] --out-def-json [OUT_DEF_JSON]
+```
+
 ## Temporary directory
 
 There are four types of storages. Each storage except for URL has its own temporary directory/bucket defined by the following parameters. 

--- a/README.md
+++ b/README.md
@@ -65,22 +65,22 @@ Examples:
 * `run`: To run a single workflow. Add `--hold` to put an hold to submitted workflows.
 ```bash
 $ caper run [WDL] -i [INPUT_JSON]
-``
+```
 
 * `server`: To start a server
 ```bash
 $ caper server
-``
+```
 
 * `submit`: To submit a workflow to a server. `-s` is optional but useful for other subcommands to find submitted workflow with matching string label.
 ```bash
 $ caper submit [WDL] -i [INPUT_JSON] -s [STR_LABEL]
-``
+```
 
 * `list`: To show list of all workflows submitted to a cromwell server. Wildcard search with using `*` and `?` is allowed for such label for the following subcommands with `STR_LABEL`. 
 ```bash
 $ caper list [WF_ID or STR_LABEL]
-``
+```
 
 * Other subcommands: Other subcommands work similar to `list`. It does a corresponding action for matched workflows.
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,27 @@ Caper is based on Unix and cloud platform CLIs (`wget`, `curl`, `gsutil` and `aw
 ## Features
 
 * **Similar CLI**: Caper has a similar CLI as Cromwell.
+
 * **Built-in backends**: You don't need your own backend configuration file. Caper provides built-in backends.
+
 * **Automatic transfer between local/cloud storages**: You can use URIs (e.g. `gs://`, `http://` and `s3://) instead of paths in a command line arguments, also in your input JSON file. Files associated with these URIs will be automatically transfered to a specified temporary directory on a target remote storage.
+
 * **Deepcopy for input JSON file**: Recursively copy all data files in (`.json`, `.tsv` and `.csv`) to a target remote storage.
+
 * **Docker/Singularity integration**: You can run a WDL workflow in a specifed docker/singularity container.
+
 * **MySQL database integration**: We provides shells scripts to run MySQL database in a docker/singularity container. Using Caper with MySQL database will allow you to use Cromwell's [call-caching](https://cromwell.readthedocs.io/en/develop/Configuring/#call-caching) to re-use outputs from previous successful tasks.
+
 * **One configuration file for all**: You may not want to repeat writing same command line parameters for every pipeline run. Define parameters in a configuration file at `~/.caper/default.conf`.
+
 * **One server for six backends**: Built-in backends allow you to submit pipelines to any local/remote backend specified with `-b` or `--backend`.
+
 * **Cluster engine support**: SLURM, SGE and PBS are currently supported locally.
+
 * **Easy workflow management**: Find all workflows submitted to a Cromwell server by workflow IDs (UUIDs) or `str_label` (special label for a workflow submitted by Caper `submit` and `run`). You can define multiple keywords with wildcards (`*` and `?`) to search for matching workflows. Abort, release hold, retrieve metadata JSON for them.
+
 * **Automatic subworkflow packing**: Caper automatically creates an archive (`imports.zip`) of all imports and send it to Cromwell server/run.
+
 * **Special label** (`str_label`): You have a string label, specified with `-s` or `--str-label`, for your workflow so that you can search for your workflow by this label instead of Cromwell's workflow UUID (e.g. `f12526cb-7ed8-4bfa-8e2e-a463e94a61d0`).
 
 ## Installation
@@ -35,18 +46,59 @@ $ git clone https://github.com/ENCODE-DCC/caper
 $ echo "export PATH=\"\$PATH:$PWD/caper/bin\"" >> ~/.bashrc
 ```
 
+## Usage
+
+There are 7 subcommands available for Caper. Except for `run` other subcommands work with a running Cromwell server, which can be started with `server` subcommand. `server` does not require a positional argument. `WF_ID` (workflow ID) is a UUID generated from Cromwell to identify a workflow. `STR_LABEL` is Caper's special string label to be used to identify a workflow.
+
+**Subcommand**|**Positional args** | **Description**
+:--------|:-----|:-----
+server   |      |Run a Cromwell server with built-in backends
+run      | WDL  |Run a single workflow
+submit   | WDL  |Submit a workflow to a Cromwell server
+abort    | WF_ID or STR_LABEL |Abort a running/pending workflow on a Cromwell server
+unhold   | WF_ID or STR_LABEL |Release hold of workflows on a Cromwell server
+list     | WF_ID or STR_LABEL |List running/pending workflows on a Cromwell server
+metadata | WF_ID or STR_LABEL |Retrieve metadata JSONs for workflows
+
+Examples:
+
+* `run`: To run a single workflow. Add `--hold` to put an hold to submitted workflows.
+```bash
+$ caper run [WDL] -i [INPUT_JSON]
+``
+
+* `server`: To start a server
+```bash
+$ caper server
+``
+
+* `submit`: To submit a workflow to a server. `-s` is optional but useful for other subcommands to find submitted workflow with matching string label.
+```bash
+$ caper submit [WDL] -i [INPUT_JSON] -s [STR_LABEL]
+``
+
+* `list`: To show list of all workflows submitted to a cromwell server. Wildcard search with using `*` and `?` is allowed for such label for the following subcommands with `STR_LABEL`. 
+```bash
+$ caper list [WF_ID or STR_LABEL]
+``
+
+* Other subcommands: Other subcommands work similar to `list`. It does a corresponding action for matched workflows.
+
+
+
 ## Configuration file
 
-`Caper` automatically creates a default configuration file at `~/.caper/default.conf`. Such configruation file comes with all available parameters commented out. You can uncomment/define any parameter to activate it.
+Caper automatically creates a default configuration file at `~/.caper/default.conf`. Such configruation file comes with all available parameters commented out. You can uncomment/define any parameter to activate it.
 
 You can avoid repeatedly defining same parameters in your command line arguments by using a configuration file. For example, you can define `out_dir` and `tmp_dir` in your configuration file instead of defining them in command line arguments.
 ```
-$ caper run your.wdl --out-dir [LOCAL_OUT_DIR] --tmp-dir [LOCAL_TMP_DIR]
+$ caper run [WDL] --out-dir [LOCAL_OUT_DIR] --tmp-dir [LOCAL_TMP_DIR]
 ```
 
 Equivalent settings in a configuration file.
 ```
 [defaults]
+
 out-dir=[LOCAL_OUT_DIR]
 tmp-dir=[LOCAL_TMP_DIR]
 ```
@@ -55,92 +107,117 @@ tmp-dir=[LOCAL_TMP_DIR]
 
 We highly recommend to use a default configuration file explained in the section [Configuration file](#configuration-file). Note that both dash (`-`) and underscore (`_`) are allowed for key names in a configuration file.
 
-**Cmd. line arg.**|**Description**
-:-----:|:-----:
---inputs, -i|Workflow inputs JSON file
---options, -o|Workflow options JSON file
---labels, -l|Workflow labels JSON file
---imports, -p|Zip file of imported subworkflows
+* Basic parameters that are similar to Cromwell.
 
-**Cmd. line arg.**|**Description**
-:-----:|:-----:
---str-label, -s|Caper's special label for a workflow. This will be used to identify a workflow submitted by Caper
---docker|Docker image URI for a WDL
---singularity|Singaularity image URI for a WDL
---use-docker|Use docker image for all tasks in a workflow by adding docker URI into docker runtime-attribute
---use-singularity|Use singularity image for all tasks in a workflow
+	**Cmd. line arg.**|**Description**
+	:-----|:-----
+	--inputs, -i|Workflow inputs JSON file
+	--options, -o|Workflow options JSON file
+	--labels, -l|Workflow labels JSON file
+	--imports, -p|Zip file of imported subworkflows
 
-**Conf. file**|**Cmd. line arg.**|**Default**|**Description**
-:-----:|:-----:|:-----:|:-----:
-backend|-b, --backend|local|Caper's built-in backend to run a workflow. Supported backends: `local`, `gcp`, `aws`, `slurm`, `sge` and `pbs`. Make sure to configure for chosen backend
-hold|--hold| |Put a hold on a workflow when submitted to a Cromwell server
-deepcopy|--deepcopy| |Deepcopy input files to corresponding file local/remote storage
-deepcopy-ext|--deepcopy-ext|json,tsv|Comma-separated list of file extensions to be deepcopied. Supported exts: .json, .tsv  and .csv.
-format|--format, -f|id,status,name,str\_label,submission|Comma-separated list of items to be shown for `list` subcommand. Supported formats: `id` (workflow UUID), `status`, `name` (WDL basename), `str\_label` (Caper's special string label), `submission`, `start`, `end`
+* Caper's special parameters. You can define a docker/singularity image to run your workflow with.
 
-**Conf. file**|**Cmd. line arg.**|**Default**|**Description**
-:-----:|:-----:|:-----:|:-----:
-out-dir|--out-dir|`$CWD`|Output directory for local backend
-tmp-dir|--tmp-dir|`$CWD/caper\_tmp`|Tmp. directory for local backend
+	**Cmd. line arg.**|**Description**
+	:-----|:-----
+	--str-label, -s|Caper's special label for a workflow. This will be used to identify a workflow submitted by Caper
+	--docker|Docker image URI for a WDL
+	--singularity|Singaularity image URI for a WDL
+	--use-docker|Use docker image for all tasks in a workflow by adding docker URI into docker runtime-attribute
+	--use-singularity|Use singularity image for all tasks in a workflow
 
-**Conf. file**|**Cmd. line arg.**|**Description**
-:-----:|:-----:|:-----:
-gcp-prj|--gcp-prj|Google Cloud project
-out-gcs-bucket|--out-gcs-bucket|Output GCS bucket for GC backend
-tmp-gcs-bucket|--tmp-gcs-bucket|Tmp. GCS bucket for GC backend
+* Choose a default backend. Use `--deepcopy` to recursively auto-copy data files in your input JSON file. All data files will be automatically transferred to a target local/remote storage corresponding to a chosen backend. Make sure that you correctly configure temporary directories for source/target storages (`--tmp-dir`, `--tmp-gcs-bucket` and `--tmp-s3-bucket`).
 
-**Conf. file**|**Cmd. line arg.**|**Description**
-:-----:|:-----:|:-----:
-aws-batch-arn|--aws-batch-arn|ARN for AWS Batch
-aws-region|--aws-region|AWS region (e.g. us-west-1)
-out-s3-bucket|--out-s3-bucket|Output S3 bucket for AWS backend
-tmp-s3-bucket|--tmp-s3-bucket|Tmp. S3 bucket for AWS backend
-use-gsutil-over-aws-s3|--use-gsutil-over-aws-s3|Use `gsutil` instead of `aws s3` even for S3 buckets
+	**Conf. file**|**Cmd. line arg.**|**Default**|**Description**
+	:-----|:-----|:-----|:-----
+	backend|-b, --backend|local|Caper's built-in backend to run a workflow. Supported backends: `local`, `gcp`, `aws`, `slurm`, `sge` and `pbs`. Make sure to configure for chosen backend
+	hold|--hold| |Put a hold on a workflow when submitted to a Cromwell server
+	deepcopy|--deepcopy| |Deepcopy input files to corresponding file local/remote storage
+	deepcopy-ext|--deepcopy-ext|json,<br>tsv|Comma-separated list of file extensions to be deepcopied. Supported exts: .json, .tsv  and .csv.
+	format|--format, -f|id,status,name,<br>str\_label,submission|Comma-separated list of items to be shown for `list` subcommand. Supported formats: `id` (workflow UUID), `status`, `name` (WDL basename), `str\_label` (Caper's special string label), `submission`, `start`, `end`
 
-**Conf. file**|**Cmd. line arg.**|**Description**
-:-----:|:-----:|:-----:
-http-user|--http-user|HTTP Auth username to download data from private URLs
-http-password|--http-password|HTTP Auth password to download data from private URLs
+* Local backend settings
 
-**Conf. file**|**Cmd. line arg.**|**Default**|**Description**
-:-----:|:-----:|:-----:|:-----:
-mysql-db-ip|--mysql-db-ip|localhost|MySQL DB IP address
-mysql-db-port|--mysql-db-port|3306|MySQL DB port
-mysql-db-user|--mysql-db-user|cromwell|MySQL DB username
-mysql-db-password|--mysql-db-password|cromwell|MySQL DB password
+	**Conf. file**|**Cmd. line arg.**|**Default**|**Description**
+	:-----|:-----|:-----|:-----
+	out-dir|--out-dir|`$CWD`|Output directory for local backend
+	tmp-dir|--tmp-dir|`$CWD/caper\_tmp`|Tmp. directory for local backend
 
-**Conf. file**|**Cmd. line arg.**|**Default**|**Description**
-:-----:|:-----:|:-----:|:-----:
-ip|--ip|localhost|Cromwell server IP address or hostname
-port|--port|8000|Cromwell server port
-cromwell|--cromwell|[cromwell-40.jar](https://github.com/broadinstitute/cromwell/releases/download/40/cromwell-40.jar)|Path or URL for Cromwell JAR file
-max-concurrent-tasks|--max-concurrent-tasks|1000|Maximum number of concurrent tasks
-max-concurrent-workflows|--max-concurrent-workflows|40|Maximum number of concurrent workflows
-disable-call-caching|--disable-call-caching| |Disable Cromwell's call-caching (re-using outputs)
-backend-file|--backend-file| |Custom Cromwell backend conf file. This will override Caper's built-in backends
+* Google Cloud Platform backend settings
 
-**Conf. file**|**Cmd. line arg.**|**Description**
-:-----:|:-----:|:-----:
-slurm-partition|--slurm-partition|SLURM partition
-slurm-account|--slurm-account|SLURM account
-slurm-extra-param|--slurm-extra-param|Extra parameters for SLURM `sbatch` command
+	**Conf. file**|**Cmd. line arg.**|**Description**
+	:-----|:-----|:-----
+	gcp-prj|--gcp-prj|Google Cloud project
+	out-gcs-bucket|--out-gcs-bucket|Output GCS bucket for GC backend
+	tmp-gcs-bucket|--tmp-gcs-bucket|Tmp. GCS bucket for GC backend
 
-**Conf. file**|**Cmd. line arg.**|**Description**
-:-----:|:-----:|:-----:
-sge-pe|--sge-pe|SGE parallel environment. Check with `qconf -spl`
-sge-queue|--sge-queue|SGE queue to submit tasks. Check with `qconf -sql`
-slurm-extra-param|--slurm-extra-param|Extra parameters for SGE `qsub` command
+* AWS backend settings
 
-**Conf. file**|**Cmd. line arg.**|**Description**
-:-----:|:-----:|:-----:
-pbs-queue|--pbs-queue|PBS queue to submit tasks.
-pbs-extra-param|--pbs-extra-param|Extra parameters for PBS `qsub` command
+	**Conf. file**|**Cmd. line arg.**|**Description**
+	:-----|:-----|:-----
+	aws-batch-arn|--aws-batch-arn|ARN for AWS Batch
+	aws-region|--aws-region|AWS region (e.g. us-west-1)
+	out-s3-bucket|--out-s3-bucket|Output S3 bucket for AWS backend
+	tmp-s3-bucket|--tmp-s3-bucket|Tmp. S3 bucket for AWS backend
+	use-gsutil-over-aws-s3|--use-gsutil-over-aws-s3|Use `gsutil` instead of `aws s3` even for S3 buckets
 
-## How to configure for each backend
+* Private URLs settings. This is useful, particularly for [ENCODE portal](https://www.encodeproject.org/), to use private URLs (`http(s)://`) in your input JSON.
+
+	**Conf. file**|**Cmd. line arg.**|**Description**
+	:-----|:-----|:-----
+	http-user|--http-user|HTTP Auth username to download data from private URLs
+	http-password|--http-password|HTTP Auth password to download data from private URLs
+
+* MySQL settings. Run a MySQL server with [shell scripts](/mysql) we provide and make Cromwell server connect to it instead of using its in-memory database. This is useful when you need to re-use outputs from previous failed workflows when you resume them.
+
+	**Conf. file**|**Cmd. line arg.**|**Default**|**Description**
+	:-----|:-----|:-----|:-----
+	mysql-db-ip|--mysql-db-ip|localhost|MySQL DB IP address
+	mysql-db-port|--mysql-db-port|3306|MySQL DB port
+	mysql-db-user|--mysql-db-user|cromwell|MySQL DB username
+	mysql-db-password|--mysql-db-password|cromwell|MySQL DB password
+
+* Cromwell server settings. IP address and port for a Cromwell server.
+
+	**Conf. file**|**Cmd. line arg.**|**Default**|**Description**
+	:-----|:-----|:-----|:-----
+	ip|--ip|localhost|Cromwell server IP address or hostname
+	port|--port|8000|Cromwell server port
+	cromwell|--cromwell|[cromwell-40.jar](https://github.com/broadinstitute/cromwell/releases/download/40/cromwell-40.jar)|Path or URL for Cromwell JAR file
+	max-concurrent-tasks|--max-concurrent-tasks|1000|Maximum number of concurrent tasks
+	max-concurrent-workflows|--max-concurrent-workflows|40|Maximum number of concurrent workflows
+	disable-call-caching|--disable-call-caching| |Disable Cromwell's call-caching (re-using outputs)
+	backend-file|--backend-file| |Custom Cromwell backend conf file. This will override Caper's built-in backends
+
+* SLURM backend settings. This is useful for Stanford Clusters (Sherlock, SCG). Define `--slurm-partition` for Sherlock and `--slurm-account` for SCG.
+
+	**Conf. file**|**Cmd. line arg.**|**Description**
+	:-----|:-----|:-----
+	slurm-partition|--slurm-partition|SLURM partition
+	slurm-account|--slurm-account|SLURM account
+	slurm-extra-param|--slurm-extra-param|Extra parameters for SLURM `sbatch` command
+
+* SGE backend settings. Make sure to have a parallel environment configured on your system. Ask your admin to add it if not exists.
+
+	**Conf. file**|**Cmd. line arg.**|**Description**
+	:-----|:-----|:-----
+	sge-pe|--sge-pe|SGE parallel environment. Check with `qconf -spl`
+	sge-queue|--sge-queue|SGE queue to submit tasks. Check with `qconf -sql`
+	slurm-extra-param|--slurm-extra-param|Extra parameters for SGE `qsub` command
+
+* PBS backend settings.
+
+	**Conf. file**|**Cmd. line arg.**|**Description**
+	:-----|:-----|:-----
+	pbs-queue|--pbs-queue|PBS queue to submit tasks.
+	pbs-extra-param|--pbs-extra-param|Extra parameters for PBS `qsub` command
+
+
+## Built-in backends
 
 We highly recommend to use a default configuration file explained in the section [Configuration file](#configuration-file).
 
-There are six backends supported by Caper. Each backend must run on its designated storage. To use cloud backends (`gcp` and `aws`) and corresponding cloud storages (`gcs` and `s3`), you must install cloud platform's CLIs ([`gsutil`](https://cloud.google.com/storage/docs/gsutil_install) and [`aws`](https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html)). You also need to configure these CLIs for authentication. See configuration instructions for [GCP](docs/conf_gcp.md) and [AWS](docs/conf_aws.md) for details.
+There are six built-in backends for Caper. Each backend must run on its designated storage. To use cloud backends (`gcp` and `aws`) and corresponding cloud storages (`gcs` and `s3`), you must install cloud platform's CLIs ([`gsutil`](https://cloud.google.com/storage/docs/gsutil_install) and [`aws`](https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html)). You also need to configure these CLIs for authentication. See configuration instructions for [GCP](docs/conf_gcp.md) and [AWS](docs/conf_aws.md) for details. Define required parameters in command line arguments or in a configuration file.
 
 | Backend | Description          | Storage | Required parameters                                                     |
 |---------|----------------------|---------|-------------------------------------------------------------------------|
@@ -151,39 +228,96 @@ There are six backends supported by Caper. Each backend must run on its designat
 |`sge`    |local SGE backend     | `local` | `--out-dir`, `--tmp-dir`, `--sge-pe`                                    |
 |`pds`    |local PBS backend     | `local` | `--out-dir`, `--tmp-dir`                                                |
 
-* Google Cloud Platform (`gcp`): Make sure that you already configured `gcloud` and `gsutil` correctly and passed authentication for them (e.g. `gcloud auth login`). You need to define `--gcp-prj`, `--out-gcs-bucket` and `--tmp-gcs-bucket` in your command line arguments or in your configuration file.
-	```
-	$ caper run my.wdl -b gcp --gcp-prj [GOOGLE_PRJ_NAME] --out-gcs-bucket [GS_OUT_DIR] --tmp-gcs-bucket [GS_TMP_DIR]
+
+## MySQL server
+
+We provide [shell scripts](mysql/) to run a MySQL server in a container with docker/singularity. Once you have a running MySQL server, define MySQL-related parameters in Caper to make Cromwell server connect to it. One of the advantages of using MySQL server is to use Cromwell's [call-caching](https://cromwell.readthedocs.io/en/develop/Configuring/#call-caching) to re-use outputs from previous successful tasks. You can simply re-run failed workflows with the same command line you used to start them.
+
+ You can take advan
+
+1) docker
+
+	Run the following command line. `[PORT]`, `[MYSQL_USER]`, `[MYSQL_PASSWORD]` and `[CONTAINER_NAME]` are optional. MySQL server will run in background.
+
+	```bash
+	$ bash mysql/run_mysql_server_docker.sh [DB_DIR] [PORT] [MYSQL_USER] [MYSQL_PASSWORD] [CONTAINER_NAME]
 	```
 
-* AWS (`aws`)Make sure that you already configured `aws` correctly and passed authentication for them (e.g. `aws configure`). You need to define `--aws-batch-arn`, `--aws-region`, `--out-s3-bucket` and `--tmp-s3-bucket` in your command line arguments or in your configuration file.
-	```
-	$ caper run my.wdl -b aws --aws-batch-arn [AWS_BATCH_ARN] --aws-region [AWS_REGION] --out-s3-bucket [S3_OUT_DIR] --tmp-s3-bucket [S3_TMP_DIR]
+	A general usage is:
+	```bash
+	Usage: ./run_mysql_server_docker.sh [DB_DIR] [PORT] [MYSQL_USER] [MYSQL_PASSWORD] [CONTAINER_NAME]
+
+	Example: run_mysql_server_docker.sh ~/cromwell_data_dir 3307
+
+	[DB_DIR]: This directory will be mapped to /var/lib/mysql inside a container
+	[PORT] (optional): MySQL database port for docker host (default: 3306)
+	[MYSQL_USER] (optional): MySQL username (default: cromwell)
+	[MYSQL_PASSWORD] (optional): MySQL password (default: cromwell)
+	[CONTAINER_NAME] (optional): MySQL container name (default: mysql_cromwell)
 	```
 
-* All local backends (`Local`, `slurm`, `sge` and `pbs`): You need to define `--out-dir` and `--tmp-dir` in your command line arguments or in your configuration file.
-	```
-	$ caper run my.wdl -b [BACKEND] --out-dir [OUT_DIR] --tmp-dir [TMP_DIR]
-	```
-
-* SLURM backend (`slurm`): You need to define `--slurm-account` or `--slurm-partition` in your command line arguments or in your configuration file.
-
-	> **WARNING: If your SLURM cluster does not require you to specify a partition or an account then skip them.
-	```
-	$ caper run my.wdl -b slurm --slurm-account [YOUR_SLURM_ACCOUNT] --slurm-partition [YOUR_SLURM_PARTITON]
+	If you see any conflict in `[PORT]` and `[CONTAINER_NAME]`:
+	```bash
+	docker: Error response from daemon: Conflict. The container name "/mysql_cromwell" is already in use by container 0584ec7affed0555a4ecbd2ed86a345c542b3c60993960408e72e6ea803cb97e. You have to remove (or rename) that container to be able to reuse that name..
 	```
 
-* SGE backend (`sge`): You need to define `--sge-pe` in your command line arguments or in your configuration file.
-	
-	> **WARNING: If you don't have a parallel environment (PE) then ask your SGE admin to add one.
-	```
-	$ caper run my.wdl -b sge --sge-pe [YOUR_PE]
+	Then remove a conflicting container and try with different port and container name.
+	```bash
+	$ docker stop [CONTAINER_NAME]  # you can also use a container ID found in the above cmd
+	$ docker rm [CONTAINER_NAME]
 	```
 
-* PBS backend (`pbs`): There are no required parameters for PBS backend.
+	To stop/kill a running MySQL server,
+	```bash
+	$ docker ps  # find your MySQL docker container
+	$ docker stop [CONTAINER_NAME]  # you can also use a container ID found in the above cmd
+	$ docker rm [CONTAINER_NAME]
 	```
-	$ caper run my.wdl -b pbs
+
+	If you see the following authentication error:
+	```bash
+	Caused by: java.sql.SQLException: Access denied for user 'cromwell'@'localhost' (using password: YES)
 	```
+
+	Then try to remove a volume for MySQL's docker container. See [this](https://github.com/docker-library/mariadb/issues/62#issuecomment-366933805) for details.
+	```bash
+	$ docker volume ls  # find [VOLUME_ID] for your container
+	$ docker volume rm [VOLUME_ID]
+	```
+
+2) Singularity
+
+	Run the following command line. `[PORT]`, `[MYSQL_USER]`, `[MYSQL_PASSWORD]` and `[CONTAINER_NAME]` are optional. MySQL server will run in background.
+
+	```bash
+	$ bash mysql/run_mysql_server_singularity.sh [DB_DIR] [PORT] [MYSQL_USER] [MYSQL_PASSWORD] [CONTAINER_NAME]
+	```
+
+	A general usage is:
+	```bash
+	Usage: ./run_mysql_server_singularity.sh [DB_DIR] [PORT] [MYSQL_USER] [MYSQL_PASSWORD] [CONTAINER_NAME]
+
+	Example: run_mysql_server_singularity.sh ~/cromwell_data_dir 3307
+
+	[DB_DIR]: This directory will be mapped to /var/lib/mysql inside a container
+	[PORT] (optional): MySQL database port for singularity host (default: 3306)
+	[MYSQL_USER] (optional): MySQL username (default: cromwell)
+	[MYSQL_PASSWORD] (optional): MySQL password (default: cromwell)
+	[CONTAINER_NAME] (optional): MySQL container name (default: mysql_cromwell)
+	```
+
+	If you see any conflict in `[PORT]` and `[CONTAINER_NAME]`, then remove a conflicting container and try with different port and container name.
+	```bash
+	$ singularity instance list
+	$ singularity instance stop [CONTAINER_NAME]
+	```
+
+	To stop/kill a running MySQL server,
+	```bash
+	$ singularity instance list  # find your MySQL singularity container
+	$ singularity instance stop [CONTAINER_NAME]
+	```
+
 
 ## Temporary directory
 
@@ -243,7 +377,9 @@ Example:
 
 ### Working with private URLs
 
-To have access to password-protected (HTTP Auth) private URLs, provide username and password in command line arguments (`--http-user` and `--http-password`) or in a configuration file.
+To have access to password-protected (HTTP Auth) private URLs, provide username and password in command line arguments (`--http-user` and `--http-password`) or in a configuration file. This is particularly useful for downloading genomic data files on [ENCODE portal](https://www.encodeproject.org/).
+
+Example:
 ```
 $ caper run http://password.protected.server.com/my.wdl -i http://password.protected.server.com/my.inputs.json --http-user [HTTP_USERNAME] --http-password [HTTP_PASSWORD] 
 ```
@@ -268,8 +404,8 @@ $ caper run http://password.protected.server.com/my.wdl -i http://password.prote
 > **Optional**: Add the following comments to your WDL then Caper will be able to find an appropriate container image for your WDL. Then you don't have to define them in command line arguments everytime you run a pipeline.
 
 ```bash
-#CAPER singularity docker://ubuntu:latest
-#CAPER docker ubuntu:latest
+#CAPER singularity [SINGULARITY_IMAGE_URI: e.g. docker://ubuntu:latest or shub://SUI-HPC/mysql]
+#CAPER docker [DOCKER_IMAGE_URI: e.g. ubuntu:latest]
 ```
 
 ## Requirements
@@ -284,86 +420,3 @@ $ caper run http://password.protected.server.com/my.wdl -i http://password.prote
 	```bash
 	$ aws configure
 	```
-
-## Running a MySQL server with Docker
-
-We provide [a shell script](mysql/run_mysql_server_docker.sh) to run a MySQL server with docker. Run the following command line. `[PORT]`, `[MYSQL_USER]`, `[MYSQL_PASSWORD]` and `[CONTAINER_NAME]` are optional. MySQL server will run in background.
-
-```bash
-$ bash mysql/run_mysql_server_docker.sh [DB_DIR] [PORT] [MYSQL_USER] [MYSQL_PASSWORD] [CONTAINER_NAME]
-```
-
-A general usage is:
-```bash
-Usage: ./run_mysql_server_docker.sh [DB_DIR] [PORT] [MYSQL_USER] [MYSQL_PASSWORD] [CONTAINER_NAME]
-
-Example: run_mysql_server_docker.sh ~/cromwell_data_dir 3307
-
-[DB_DIR]: This directory will be mapped to /var/lib/mysql inside a container
-[PORT] (optional): MySQL database port for docker host (default: 3306)
-[MYSQL_USER] (optional): MySQL username (default: cromwell)
-[MYSQL_PASSWORD] (optional): MySQL password (default: cromwell)
-[CONTAINER_NAME] (optional): MySQL container name (default: mysql_cromwell)
-```
-
-If you see any conflict in `[PORT]` and `[CONTAINER_NAME]`:
-```bash
-docker: Error response from daemon: Conflict. The container name "/mysql_cromwell" is already in use by container 0584ec7affed0555a4ecbd2ed86a345c542b3c60993960408e72e6ea803cb97e. You have to remove (or rename) that container to be able to reuse that name..
-```
-
-Then remove a conflicting container and try with different port and container name.
-```bash
-$ docker stop [CONTAINER_NAME]  # you can also use a container ID found in the above cmd
-$ docker rm [CONTAINER_NAME]
-```
-
-To stop/kill a running MySQL server,
-```bash
-$ docker ps  # find your MySQL docker container
-$ docker stop [CONTAINER_NAME]  # you can also use a container ID found in the above cmd
-$ docker rm [CONTAINER_NAME]
-```
-
-If you see the following authentication error:
-```bash
-Caused by: java.sql.SQLException: Access denied for user 'cromwell'@'localhost' (using password: YES)
-```
-
-Then try to remove a volume for MySQL's docker container. See [this](https://github.com/docker-library/mariadb/issues/62#issuecomment-366933805) for details.
-```bash
-$ docker volume ls  # find [VOLUME_ID] for your container
-$ docker volume rm [VOLUME_ID]
-```
-
-## Running a MySQL server with Singularity
-
-We provide [a shell script](mysql/run_mysql_server_singularity.sh) to run a MySQL server with singularity. Run the following command line. `[PORT]`, `[MYSQL_USER]`, `[MYSQL_PASSWORD]` and `[CONTAINER_NAME]` are optional. MySQL server will run in background.
-
-```bash
-$ bash mysql/run_mysql_server_singularity.sh [DB_DIR] [PORT] [MYSQL_USER] [MYSQL_PASSWORD] [CONTAINER_NAME]
-```
-
-A general usage is:
-```bash
-Usage: ./run_mysql_server_singularity.sh [DB_DIR] [PORT] [MYSQL_USER] [MYSQL_PASSWORD] [CONTAINER_NAME]
-
-Example: run_mysql_server_singularity.sh ~/cromwell_data_dir 3307
-
-[DB_DIR]: This directory will be mapped to /var/lib/mysql inside a container
-[PORT] (optional): MySQL database port for singularity host (default: 3306)
-[MYSQL_USER] (optional): MySQL username (default: cromwell)
-[MYSQL_PASSWORD] (optional): MySQL password (default: cromwell)
-[CONTAINER_NAME] (optional): MySQL container name (default: mysql_cromwell)
-```
-
-If you see any conflict in `[PORT]` and `[CONTAINER_NAME]`, then remove a conflicting container and try with different port and container name.
-```bash
-$ singularity instance list
-$ singularity instance stop [CONTAINER_NAME]
-```
-
-To stop/kill a running MySQL server,
-```bash
-$ singularity instance list  # find your MySQL singularity container
-$ singularity instance stop [CONTAINER_NAME]
-```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Caper (Cromwell Assisted Pipeline ExecutoR) is a wrapper Python package for [Cro
 
 ## Introduction
 
-Caper is based on Unix and cloud platform CLIs (`wget`, `curl`, `gsutil` and `aws`) and provides easier way of running Cromwell server/run modes by automatically composing necessary input files for Cromwell. Also, Caper supports easy automatic file transfer between local/cloud storages (local path, `s3://`, `gs://` and `http(s)://`). You can use these URIs in input JSON file or for a WDL file itself.
+Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and provides easier way of running Cromwell server/run modes by automatically composing necessary input files for Cromwell. Also, Caper supports easy automatic file transfer between local/cloud storages (local path, `s3://`, `gs://` and `http(s)://`). You can use these URIs in input JSON file or for a WDL file itself.
 
 ## Features
 
@@ -12,13 +12,13 @@ Caper is based on Unix and cloud platform CLIs (`wget`, `curl`, `gsutil` and `aw
 
 * **Built-in backends**: You don't need your own backend configuration file. Caper provides built-in backends.
 
-* **Automatic transfer between local/cloud storages**: You can use URIs (e.g. `gs://`, `http://` and `s3://) instead of paths in a command line arguments, also in your input JSON file. Files associated with these URIs will be automatically transfered to a specified temporary directory on a target remote storage.
+* **Automatic transfer between local/cloud storages**: You can use URIs (e.g. `gs://`, `http://` and `s3://`) instead of paths in a command line arguments, also in your input JSON file. Files associated with these URIs will be automatically transfered to a specified temporary directory on a target remote storage.
 
 * **Deepcopy for input JSON file**: Recursively copy all data files in (`.json`, `.tsv` and `.csv`) to a target remote storage.
 
 * **Docker/Singularity integration**: You can run a WDL workflow in a specifed docker/singularity container.
 
-* **MySQL database integration**: We provides shells scripts to run MySQL database in a docker/singularity container. Using Caper with MySQL database will allow you to use Cromwell's [call-caching](https://cromwell.readthedocs.io/en/develop/Configuring/#call-caching) to re-use outputs from previous successful tasks.
+* **MySQL database integration**: We provide shell scripts to run a MySQL database server in a docker/singularity container. Using Caper with MySQL database will allow you to use Cromwell's [call-caching](https://cromwell.readthedocs.io/en/develop/Configuring/#call-caching) to re-use outputs from previous successful tasks. This will be useful to resume a failed workflow where it left off.
 
 * **One configuration file for all**: You may not want to repeat writing same command line parameters for every pipeline run. Define parameters in a configuration file at `~/.caper/default.conf`.
 
@@ -63,24 +63,28 @@ metadata | WF_ID or STR_LABEL |Retrieve metadata JSONs for workflows
 Examples:
 
 * `run`: To run a single workflow. Add `--hold` to put an hold to submitted workflows.
-```bash
-$ caper run [WDL] -i [INPUT_JSON]
-```
+
+	```bash
+	$ caper run [WDL] -i [INPUT_JSON]
+	```
 
 * `server`: To start a server
-```bash
-$ caper server
-```
+
+	```bash
+	$ caper server
+	```
 
 * `submit`: To submit a workflow to a server. `-s` is optional but useful for other subcommands to find submitted workflow with matching string label.
-```bash
-$ caper submit [WDL] -i [INPUT_JSON] -s [STR_LABEL]
-```
+
+	```bash
+	$ caper submit [WDL] -i [INPUT_JSON] -s [STR_LABEL]
+	```
 
 * `list`: To show list of all workflows submitted to a cromwell server. Wildcard search with using `*` and `?` is allowed for such label for the following subcommands with `STR_LABEL`. 
-```bash
-$ caper list [WF_ID or STR_LABEL]
-```
+
+	```bash
+	$ caper list [WF_ID or STR_LABEL]
+	```
 
 * Other subcommands: Other subcommands work similar to `list`. It does a corresponding action for matched workflows.
 
@@ -109,7 +113,7 @@ We highly recommend to use a default configuration file explained in the section
 
 * Basic parameters that are similar to Cromwell.
 
-	**Cmd. line arg.**|**Description**
+	**Cmd. line**|**Description**
 	:-----|:-----
 	--inputs, -i|Workflow inputs JSON file
 	--options, -o|Workflow options JSON file
@@ -118,7 +122,7 @@ We highly recommend to use a default configuration file explained in the section
 
 * Caper's special parameters. You can define a docker/singularity image to run your workflow with.
 
-	**Cmd. line arg.**|**Description**
+	**Cmd. line**|**Description**
 	:-----|:-----
 	--str-label, -s|Caper's special label for a workflow. This will be used to identify a workflow submitted by Caper
 	--docker|Docker image URI for a WDL
@@ -128,24 +132,24 @@ We highly recommend to use a default configuration file explained in the section
 
 * Choose a default backend. Use `--deepcopy` to recursively auto-copy data files in your input JSON file. All data files will be automatically transferred to a target local/remote storage corresponding to a chosen backend. Make sure that you correctly configure temporary directories for source/target storages (`--tmp-dir`, `--tmp-gcs-bucket` and `--tmp-s3-bucket`).
 
-	**Conf. file**|**Cmd. line arg.**|**Default**|**Description**
+	**Conf. file**|**Cmd. line**|**Default**|**Description**
 	:-----|:-----|:-----|:-----
 	backend|-b, --backend|local|Caper's built-in backend to run a workflow. Supported backends: `local`, `gcp`, `aws`, `slurm`, `sge` and `pbs`. Make sure to configure for chosen backend
 	hold|--hold| |Put a hold on a workflow when submitted to a Cromwell server
 	deepcopy|--deepcopy| |Deepcopy input files to corresponding file local/remote storage
 	deepcopy-ext|--deepcopy-ext|json,<br>tsv|Comma-separated list of file extensions to be deepcopied. Supported exts: .json, .tsv  and .csv.
-	format|--format, -f|id,status,name,<br>str\_label,submission|Comma-separated list of items to be shown for `list` subcommand. Supported formats: `id` (workflow UUID), `status`, `name` (WDL basename), `str\_label` (Caper's special string label), `submission`, `start`, `end`
+	format|--format, -f|id,status,<br>name,<br>str_label,<br>submission|Comma-separated list of items to be shown for `list` subcommand. Supported formats: `id` (workflow UUID), `status`, `name` (WDL basename), `str\_label` (Caper's special string label), `submission`, `start`, `end`
 
 * Local backend settings
 
-	**Conf. file**|**Cmd. line arg.**|**Default**|**Description**
+	**Conf. file**|**Cmd. line**|**Default**|**Description**
 	:-----|:-----|:-----|:-----
 	out-dir|--out-dir|`$CWD`|Output directory for local backend
 	tmp-dir|--tmp-dir|`$CWD/caper\_tmp`|Tmp. directory for local backend
 
 * Google Cloud Platform backend settings
 
-	**Conf. file**|**Cmd. line arg.**|**Description**
+	**Conf. file**|**Cmd. line**|**Description**
 	:-----|:-----|:-----
 	gcp-prj|--gcp-prj|Google Cloud project
 	out-gcs-bucket|--out-gcs-bucket|Output GCS bucket for GC backend
@@ -153,7 +157,7 @@ We highly recommend to use a default configuration file explained in the section
 
 * AWS backend settings
 
-	**Conf. file**|**Cmd. line arg.**|**Description**
+	**Conf. file**|**Cmd. line**|**Description**
 	:-----|:-----|:-----
 	aws-batch-arn|--aws-batch-arn|ARN for AWS Batch
 	aws-region|--aws-region|AWS region (e.g. us-west-1)
@@ -163,14 +167,14 @@ We highly recommend to use a default configuration file explained in the section
 
 * Private URLs settings. This is useful, particularly for [ENCODE portal](https://www.encodeproject.org/), to use private URLs (`http(s)://`) in your input JSON.
 
-	**Conf. file**|**Cmd. line arg.**|**Description**
+	**Conf. file**|**Cmd. line**|**Description**
 	:-----|:-----|:-----
 	http-user|--http-user|HTTP Auth username to download data from private URLs
 	http-password|--http-password|HTTP Auth password to download data from private URLs
 
 * MySQL settings. Run a MySQL server with [shell scripts](/mysql) we provide and make Cromwell server connect to it instead of using its in-memory database. This is useful when you need to re-use outputs from previous failed workflows when you resume them.
 
-	**Conf. file**|**Cmd. line arg.**|**Default**|**Description**
+	**Conf. file**|**Cmd. line**|**Default**|**Description**
 	:-----|:-----|:-----|:-----
 	mysql-db-ip|--mysql-db-ip|localhost|MySQL DB IP address
 	mysql-db-port|--mysql-db-port|3306|MySQL DB port
@@ -179,7 +183,7 @@ We highly recommend to use a default configuration file explained in the section
 
 * Cromwell server settings. IP address and port for a Cromwell server.
 
-	**Conf. file**|**Cmd. line arg.**|**Default**|**Description**
+	**Conf. file**|**Cmd. line**|**Default**|**Description**
 	:-----|:-----|:-----|:-----
 	ip|--ip|localhost|Cromwell server IP address or hostname
 	port|--port|8000|Cromwell server port
@@ -191,7 +195,7 @@ We highly recommend to use a default configuration file explained in the section
 
 * SLURM backend settings. This is useful for Stanford Clusters (Sherlock, SCG). Define `--slurm-partition` for Sherlock and `--slurm-account` for SCG.
 
-	**Conf. file**|**Cmd. line arg.**|**Description**
+	**Conf. file**|**Cmd. line**|**Description**
 	:-----|:-----|:-----
 	slurm-partition|--slurm-partition|SLURM partition
 	slurm-account|--slurm-account|SLURM account
@@ -199,7 +203,7 @@ We highly recommend to use a default configuration file explained in the section
 
 * SGE backend settings. Make sure to have a parallel environment configured on your system. Ask your admin to add it if not exists.
 
-	**Conf. file**|**Cmd. line arg.**|**Description**
+	**Conf. file**|**Cmd. line**|**Description**
 	:-----|:-----|:-----
 	sge-pe|--sge-pe|SGE parallel environment. Check with `qconf -spl`
 	sge-queue|--sge-queue|SGE queue to submit tasks. Check with `qconf -sql`
@@ -207,7 +211,7 @@ We highly recommend to use a default configuration file explained in the section
 
 * PBS backend settings.
 
-	**Conf. file**|**Cmd. line arg.**|**Description**
+	**Conf. file**|**Cmd. line**|**Description**
 	:-----|:-----|:-----
 	pbs-queue|--pbs-queue|PBS queue to submit tasks.
 	pbs-extra-param|--pbs-extra-param|Extra parameters for PBS `qsub` command
@@ -231,9 +235,7 @@ There are six built-in backends for Caper. Each backend must run on its designat
 
 ## MySQL server
 
-We provide [shell scripts](mysql/) to run a MySQL server in a container with docker/singularity. Once you have a running MySQL server, define MySQL-related parameters in Caper to make Cromwell server connect to it. One of the advantages of using MySQL server is to use Cromwell's [call-caching](https://cromwell.readthedocs.io/en/develop/Configuring/#call-caching) to re-use outputs from previous successful tasks. You can simply re-run failed workflows with the same command line you used to start them.
-
- You can take advan
+We provide [shell scripts](mysql/) to run a MySQL server in a container with docker/singularity. Once you have a running MySQL server, define MySQL-related parameters in Caper to make Cromwell server connect to it. One of the advantages of using MySQL server is to use Cromwell's [call-caching](https://cromwell.readthedocs.io/en/develop/Configuring/#call-caching) to re-use outputs from previous successful tasks. You can simply restart failed workflows with the same command line you used to start them.
 
 1) docker
 
@@ -318,6 +320,54 @@ We provide [shell scripts](mysql/) to run a MySQL server in a container with doc
 	$ singularity instance stop [CONTAINER_NAME]
 	```
 
+## HPC clusters
+
+For users on Stanford HPC clusters (Sherlock and SCG). We recommend to run a MySQL server and run a Cromwell server attached to it. Set up a configuration file like the following.
+
+```bash
+[defaults]
+
+# define your SLURM partition for Sherlock
+slurm-partition=
+
+# define your SLURM account for SCG
+slurm-account=
+
+# for both cluster, define a temporary directory
+# all temporary files will be stored here
+# scratch directory is recommended
+# do not use /tmp
+tmp-dir=
+
+# for both cluster, define a output directory
+# actual pipeline outputs will be stored here
+out-dir=
+
+# MySQL database settings
+# default port is 3306 but if it's already taken
+# use a different port
+mysql-db-port=3307
+```
+
+Run a MySQL database server in a singularity container.
+```bash
+$ run_mysql_server_singularity.sh [PORT]
+```
+
+Run a Cromwell server. Make sure to keep the SSH session alive where a Cromwell server runs on.
+```bash
+$ caper server
+```
+
+Submit a workflow to it instead of `sbatch`ing it. `STR_LABEL` will be useful to find your workflows.
+```bash
+$ caper submit [WDL] -i [INPUT_JSON] -s [STR_LABEL]
+```
+
+Monitor your workflows. Find by `STR_LABEL` or `WF_ID` (UUID). Wildcard search (`*` and `?`) is available.
+```bash
+$ caper list [WF_ID or STR_LABEL]
+```
 
 ## Temporary directory
 
@@ -363,9 +413,9 @@ A local file `/home/user/a/b/c/hello.gz` can be copied (on demand) to
 File transfer is done by using the following command lines using various CLIs:
 
 * `gsutil -q cp -n [SRC] [TARGET]`
-* `aws s3 cp '--only-show-errors' [SRC] [TARGET]`
-* `wget --no-check-certificate -qc [URL_SRC] -O [LOCAL_TARGET]`
-* `curl -f [URL_SRC] | gsutil -q cp -n - [TARGET]`
+* `aws s3 cp --only-show-errors [SRC] [TARGET]`
+* `curl -RL -f -C - [URL_SRC] -o [TARGET]`
+* `curl -RL -f [URL_SRC] | gsutil -q cp -n - [TARGET]`
 
 > **WARNING**: Caper does not ensure a fail-safe file transfer when it's interrupted by user or system. Also, there can be race conditions if multiple users try to access/copy files. This will be later addressed in the future release. Until then DO NOT interrupt file transfer until you see the following `copying done` message.
 
@@ -373,15 +423,6 @@ Example:
 ```
 [CaperURI] copying from gcs to local, src: gs://encode-pipeline-test-runs/test_wdl_imports/main.wdl
 [CaperURI] copying done, target: /srv/scratch/leepc12/caper_tmp_dir/encode-pipeline-test-runs/test_wdl_imports/main.wdl
-```
-
-### Working with private URLs
-
-To have access to password-protected (HTTP Auth) private URLs, provide username and password in command line arguments (`--http-user` and `--http-password`) or in a configuration file. This is particularly useful for downloading genomic data files on [ENCODE portal](https://www.encodeproject.org/).
-
-Example:
-```
-$ caper run http://password.protected.server.com/my.wdl -i http://password.protected.server.com/my.inputs.json --http-user [HTTP_USERNAME] --http-password [HTTP_PASSWORD] 
 ```
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ We highly recommend to use a default configuration file described in the section
 	--options, -o|Workflow options JSON file
 	--labels, -l|Workflow labels JSON file
 	--imports, -p|Zip file of imported subworkflows
+	--metadata-output, -m|Path for output metadata JSON file (for `run` mode only)
 
 * Caper's special parameters. You can define a docker/singularity image to run your workflow with.
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ tmp-dir=[LOCAL_TMP_DIR]
 
 ## List of parameters
 
-We highly recommend to use a default configuration file explained in the section [Configuration file](#configuration-file). Note that both dash (`-`) and underscore (`_`) are allowed for key names in a configuration file.
+We highly recommend to use a default configuration file described in the section [Configuration file](#configuration-file). Note that both dash (`-`) and underscore (`_`) are allowed for key names in a configuration file.
 
 * Basic parameters that are similar to Cromwell.
 
@@ -225,17 +225,17 @@ There are six built-in backends for Caper. Each backend must run on its designat
 
 | Backend | Description          | Storage | Required parameters                                                     |
 |---------|----------------------|---------|-------------------------------------------------------------------------|
-|`gcp`    |Google Cloud Platform | `gcs`   | `--gcp-prj`, `--out-gcs-bucket`, `--tmp-gcs-bucket`                     |
-|`aws`    |AWS                   | `s3`    | `--aws-batch-arn`, `--aws-region`, `--out-s3-bucket`, `--tmp-s3-bucket` |
-|`Local`  |Default local backend | `local` | `--out-dir`, `--tmp-dir`                                                |
-|`slurm`  |local SLURM backend   | `local` | `--out-dir`, `--tmp-dir`, `--slurm-partition` or `--slurm-account`      |
-|`sge`    |local SGE backend     | `local` | `--out-dir`, `--tmp-dir`, `--sge-pe`                                    |
-|`pds`    |local PBS backend     | `local` | `--out-dir`, `--tmp-dir`                                                |
+|gcp    |Google Cloud Platform | gcs   | --gcp-prj, --out-gcs-bucket, --tmp-gcs-bucket                     |
+|aws    |AWS                   | s3    | --aws-batch-arn, --aws-region, --out-s3-bucket, --tmp-s3-bucket |
+|Local  |Default local backend | local | --out-dir, --tmp-dir                                                |
+|slurm  |local SLURM backend   | local | --out-dir, --tmp-dir, --slurm-partition or --slurm-account      |
+|sge    |local SGE backend     | local | --out-dir, --tmp-dir, --sge-pe                                    |
+|pds    |local PBS backend     | local | --out-dir, --tmp-dir                                                |
 
 
 ## MySQL server
 
-We provide [shell scripts](mysql/) to run a MySQL server in a container with docker/singularity. Once you have a running MySQL server, define MySQL-related parameters in Caper to make Cromwell server connect to it. One of the advantages of using MySQL server is to use Cromwell's [call-caching](https://cromwell.readthedocs.io/en/develop/Configuring/#call-caching) to re-use outputs from previous successful tasks. You can simply restart failed workflows with the same command line you used to start them.
+We provide [shell scripts](mysql/) to run a MySQL server in a container with docker/singularity. Once you have a running MySQL server, define MySQL-related parameters in Caper to attach it to a Cromwell server. One of the advantages of using MySQL server is to use Cromwell's [call-caching](https://cromwell.readthedocs.io/en/develop/Configuring/#call-caching) to re-use outputs from previous successful tasks. You can simply restart failed workflows with the same command line you used to start them.
 
 1) docker
 
@@ -349,12 +349,14 @@ out-dir=
 mysql-db-port=3307
 ```
 
-Run a MySQL database server in a singularity container.
+Run a MySQL database server in a singularity container. If you are running it for the first time, make an empty directory for `DB_DIR`. `PORT` is optional but match it with that in a configuration file.
 ```bash
-$ run_mysql_server_singularity.sh [PORT]
+$ run_mysql_server_singularity.sh [DB_DIR] [PORT]
 ```
 
-Run a Cromwell server. Make sure to keep the SSH session alive where a Cromwell server runs on.
+Run a Cromwell server.
+> **WARNING**: Make sure to keep the SSH session alive where a Cromwell server runs on.
+
 ```bash
 $ caper server
 ```
@@ -375,10 +377,10 @@ There are four types of storages. Each storage except for URL has its own tempor
 
 | Storage | URI(s)       | Command line parameter    |
 |---------|--------------|---------------------------|
-| `local` | Path         | `--tmp-dir`               |
-| `gcs`   | `gs://`      | `--tmp-gcs-bucket`        |
-| `s3`    | `s3://`      | `--tmp-s3-bucket`         |
-| `url`   | `http(s)://` | not available (read-only) |
+| local | Path         | --tmp-dir               |
+| gcs   | gs://      | --tmp-gcs-bucket        |
+| s3    | s3://      | --tmp-s3-bucket         |
+| url   | http(s):// | not available (read-only) |
 
 ## Output directory
 
@@ -386,10 +388,10 @@ Output directories are defined similarly as temporary ones. Those are actual out
 
 | Storage | URI(s)       | Command line parameter    |
 |---------|--------------|---------------------------|
-| `local` | Path         | `--out-dir`               |
-| `gcs`   | `gs://`      | `--out-gcs-bucket`        |
-| `s3`    | `s3://`      | `--out-s3-bucket`         |
-| `url`   | `http(s)://` | not available (read-only) |
+| local | Path         | --out-dir               |
+| gcs   | gs://      | --out-gcs-bucket        |
+| s3    | s3://      | --out-s3-bucket         |
+| url   | http(s):// | not available (read-only) |
 
 Workflow's final output file `metadata.json` will be written to each workflow's directory (with workflow UUID) under this output directory.
 
@@ -399,16 +401,16 @@ Inter-storage transfer is done by keeping source's directory structure and appen
 
 | Storage | Command line parameters                              |
 |---------|------------------------------------------------------|
-| `local` | `--tmp-dir /scratch/user/caper_tmp`             |
-| `gcs`   | `--tmp-gcs-bucket gs://my_gcs_bucket/caper_tmp` |
-| `s3`    | `--tmp-s3-bucket s3://my_s3_bucket/caper_tmp`   |
+| local | --tmp-dir /scratch/user/caper_tmp             |
+| gcs   | --tmp-gcs-bucket gs://my_gcs_bucket/caper_tmp |
+| s3    | --tmp-s3-bucket s3://my_s3_bucket/caper_tmp   |
 
 A local file `/home/user/a/b/c/hello.gz` can be copied (on demand) to 
 
 | Storage | Command line parameters                                      |
 |---------|--------------------------------------------------------------|
-| `gcs`   | `gs://my_gcs_bucket/caper_tmp/home/user/a/b/c/hello.gz` |
-| `s3`    | `s3://my_s3_bucket/caper_tmp/home/user/a/b/c/hello.gz`  |
+| gcs   | gs://my_gcs_bucket/caper_tmp/home/user/a/b/c/hello.gz |
+| s3    | s3://my_s3_bucket/caper_tmp/home/user/a/b/c/hello.gz  |
 
 File transfer is done by using the following command lines using various CLIs:
 
@@ -431,12 +433,12 @@ Example:
 
 | Sensitve information               | Temporary filename   |
 |------------------------------------|----------------------|
-| MySQL database username            | `backend.conf`       |
-| MySQL database password            | `backend.conf`       |
-| AWS Batch ARN                      | `backend.conf`       |
-| Google Cloud Platform project name | `backend.conf`       |
-| SLURM account name                 | `workflow_opts.json` |
-| SLURM partition name               | `workflow_opts.json` |
+| MySQL database username            | backend.conf       |
+| MySQL database password            | backend.conf       |
+| AWS Batch ARN                      | backend.conf       |
+| Google Cloud Platform project name | backend.conf       |
+| SLURM account name                 | workflow_opts.json |
+| SLURM partition name               | workflow_opts.json` |
 
 > **WARNING**: Also, please keep other temporary directories **SECURE** too. Your data files defined in your input JSON file can be recursively transferred to any of these temporary directories according to your target backend defined by `-b` or `--backend`.
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ We provide [shell scripts](mysql/) to run a MySQL server in a container with doc
 
 1) docker
 
-	Run the following command line. `[PORT]`, `[MYSQL_USER]`, `[MYSQL_PASSWORD]` and `[CONTAINER_NAME]` are optional. MySQL server will run in background.
+	Run the following command line. `PORT`, `MYSQL_USER`, `MYSQL_PASSWORD` and `CONTAINER_NAME` are optional. MySQL server will run in background.
 
 	```bash
 	$ bash mysql/run_mysql_server_docker.sh [DB_DIR] [PORT] [MYSQL_USER] [MYSQL_PASSWORD] [CONTAINER_NAME]
@@ -258,7 +258,7 @@ We provide [shell scripts](mysql/) to run a MySQL server in a container with doc
 	[CONTAINER_NAME] (optional): MySQL container name (default: mysql_cromwell)
 	```
 
-	If you see any conflict in `[PORT]` and `[CONTAINER_NAME]`:
+	If you see any conflict in `PORT` and `CONTAINER_NAME`:
 	```bash
 	docker: Error response from daemon: Conflict. The container name "/mysql_cromwell" is already in use by container 0584ec7affed0555a4ecbd2ed86a345c542b3c60993960408e72e6ea803cb97e. You have to remove (or rename) that container to be able to reuse that name..
 	```
@@ -289,7 +289,7 @@ We provide [shell scripts](mysql/) to run a MySQL server in a container with doc
 
 2) Singularity
 
-	Run the following command line. `[PORT]`, `[MYSQL_USER]`, `[MYSQL_PASSWORD]` and `[CONTAINER_NAME]` are optional. MySQL server will run in background.
+	Run the following command line. `PORT`, `MYSQL_USER`, `MYSQL_PASSWORD` and `CONTAINER_NAME` are optional. MySQL server will run in background.
 
 	```bash
 	$ bash mysql/run_mysql_server_singularity.sh [DB_DIR] [PORT] [MYSQL_USER] [MYSQL_PASSWORD] [CONTAINER_NAME]
@@ -308,7 +308,7 @@ We provide [shell scripts](mysql/) to run a MySQL server in a container with doc
 	[CONTAINER_NAME] (optional): MySQL container name (default: mysql_cromwell)
 	```
 
-	If you see any conflict in `[PORT]` and `[CONTAINER_NAME]`, then remove a conflicting container and try with different port and container name.
+	If you see any conflict in `PORT` and `CONTAINER_NAME`, then remove a conflicting container and try with different port and container name.
 	```bash
 	$ singularity instance list
 	$ singularity instance stop [CONTAINER_NAME]

--- a/bin/caper
+++ b/bin/caper
@@ -9,7 +9,6 @@ except:
     import caper
 
 from caper.caper import main
-print(caper.caper.__file__)
 
 main()
 

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -130,6 +130,7 @@ class Caper(object):
         self._str_label = args.get('str_label')
         self._labels = args.get('labels')
         self._imports = args.get('imports')
+        self._metadata_output = args.get('metadata_output')
 
         # backend and default backend
         self._backend = args.get('backend')
@@ -450,8 +451,12 @@ class Caper(object):
         else:
             path = os.path.join(out_dir, os.path.basename(wdl), workflow_id)
 
-        metadata_uri = os.path.join(
-            path, Caper.TMP_FILE_BASENAME_METADATA_JSON)
+        if self._metadata_output is not None:
+            metadata_uri = self._metadata_output
+        else:
+            metadata_uri = os.path.join(
+                path, Caper.TMP_FILE_BASENAME_METADATA_JSON)
+
         return CaperURI(metadata_uri).write_str_to_file(
             json.dumps(metadata_json, indent=4)).get_uri()
 

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -96,7 +96,7 @@ class Caper(object):
         # self._keep_temp_backend_file = args.get('keep_temp_backend_file')
         self._hold = args.get('hold')
         self._format = args.get('format')
-        self._use_call_caching = args.get('use_call_caching')
+        self._disable_call_caching = args.get('disable_call_caching')
         self._max_concurrent_workflows = args.get('max_concurrent_workflows')
         self._max_concurrent_tasks = args.get('max_concurrent_tasks')
         self._tmp_dir = args.get('tmp_dir')
@@ -671,7 +671,7 @@ class Caper(object):
             backend_dict,
             CaperBackendCommon(
                 port=self._port,
-                use_call_caching=self._use_call_caching,
+                disable_call_caching=self._disable_call_caching,
                 max_concurrent_workflows=self._max_concurrent_workflows))
 
         # local backend

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -192,8 +192,8 @@ class Caper(object):
             tmp_dir, Caper.TMP_FILE_BASENAME_METADATA_JSON)
 
         # LOG_LEVEL must be >=INFO to catch workflow ID from STDOUT
-        cmd = ['java', '-DLOG_LEVEL=INFO', '-jar',
-               '-Dconfig.file={}'.format(backend_file),
+        cmd = ['java', '-Xmx1G', '-XX:ParallelGCThreads=1', '-DLOG_LEVEL=INFO',
+               '-jar', '-Dconfig.file={}'.format(backend_file),
                CaperURI(self._cromwell).get_local_file(), 'run',
                CaperURI(self._wdl).get_local_file(),
                '-i', input_file,
@@ -251,8 +251,8 @@ class Caper(object):
         backend_file = self.__create_backend_conf_file(tmp_dir)
 
         # LOG_LEVEL must be >=INFO to catch workflow ID from STDOUT
-        cmd = ['java', '-DLOG_LEVEL=INFO', '-jar',
-               '-Dconfig.file={}'.format(backend_file),
+        cmd = ['java', '-Xmx2G', '-XX:ParallelGCThreads=1', '-DLOG_LEVEL=INFO',
+               '-jar', '-Dconfig.file={}'.format(backend_file),
                CaperURI(self._cromwell).get_local_file(), 'server']
         print('[Caper] cmd: ', cmd)
 

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -24,60 +24,14 @@ DEFAULT_FORMAT = 'id,status,name,str_label,submission'
 DEFAULT_DEEPCOPY_EXT = 'json,tsv'
 DEFAULT_CAPER_CONF_CONTENTS = """[defaults]
 
-### MySQL database settings
-#mysql-db-ip=
-#mysql-db-port=
-#mysql-db-user=cromwell
-#mysql-db-password=cromwell
+############# Caper settings
 
-### Cromwell general settings
-#cromwell=https://github.com/broadinstitute/cromwell/releases/download/40/cromwell-40.jar
-#disable-call-caching=False
-#max-concurrent-tasks=1000
-#max-concurrent-workflows=40
-
-### Cromwell server/client settings
-#ip=localhost
-#port=8000
-
-### backends general settings
 ## default backend
 #backend=local
-#backend-file=
 
-### local backend
-#out-dir=
-#tmp-dir=
-
-### Google Cloud Platform backend
-#gcp-prj=encode-dcc-1016
-#out-gcs-bucket=gs://encode-pipeline-test-runs/caper/out
-#tmp-gcs-bucket=gs://encode-pipeline-test-runs/caper/tmp
-
-### AWS backend
-#aws-batch-arn=arn:aws:batch:us-west-1:618537831167:job-queue/first-run-job-queue
-#aws-region=us-west-1
-#out-s3-bucket=s3://encode-pipeline-test-runs/caper/out
-#tmp-s3-bucket=s3://encode-pipeline-test-runs/caper/tmp
-#use-gsutil-over-aws-s3=True
-
-### HTTP auth to download from URLs (http://, https://)
-#http-user=
-#http-password=
-
-### SLURM backend
-#slurm-partition=akundaje
-#slurm-account=akundaje
-#slurm-extra-param=
-
-### SGE backend
-#sge-queue=q
-#sge-pe=shm
-#sge-extra-param=
-
-### PBS backend
-#pbs-queue=q
-#pbs-extra-param=
+## Put a hold on submitted jobs.
+## You need to run "caper unhold [WORKFLOW_ID]" to release hold
+#hold=True
 
 ### Workflow settings
 ## deepcopy recursively all file URIs in a file URI
@@ -86,9 +40,56 @@ DEFAULT_CAPER_CONF_CONTENTS = """[defaults]
 #deepcopy=True
 #deepcopy-ext=json,tsv
 
-## Put a hold on submitted jobs.
-## You need to run "caper unhold [WORKFLOW_ID]" to release hold
-#hold=True
+############# local backend
+#out-dir=
+#tmp-dir=
+
+############# Google Cloud Platform backend
+#gcp-prj=encode-dcc-1016
+#out-gcs-bucket=gs://encode-pipeline-test-runs/caper/out
+#tmp-gcs-bucket=gs://encode-pipeline-test-runs/caper/tmp
+
+############# AWS backend
+#aws-batch-arn=
+#aws-region=us-west-1
+#out-s3-bucket=s3://encode-pipeline-test-runs/caper/out
+#tmp-s3-bucket=s3://encode-pipeline-test-runs/caper/tmp
+#use-gsutil-over-aws-s3=True
+
+############# HTTP auth to download from URLs (http://, https://)
+#http-user=
+#http-password=
+
+############# MySQL database settings
+#mysql-db-ip=
+#mysql-db-port=
+#mysql-db-user=cromwell
+#mysql-db-password=cromwell
+
+############# Cromwell general settings
+#cromwell=https://github.com/broadinstitute/cromwell/releases/download/40/cromwell-40.jar
+#max-concurrent-tasks=1000
+#max-concurrent-workflows=40
+#disable-call-caching=False
+#backend-file=
+
+## Cromwell server
+#ip=localhost
+#port=8000
+
+############# SLURM backend
+#slurm-partition=akundaje
+#slurm-account=akundaje
+#slurm-extra-param=
+
+############# SGE backend
+#sge-queue=q
+#sge-pe=shm
+#sge-extra-param=
+
+############# PBS backend
+#pbs-queue=q
+#pbs-extra-param=
 
 ## list workflow format
 #format=id,status,name,str_label,submission

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -244,6 +244,12 @@ def parse_caper_arguments():
         '--hold', action='store_true',
         help='Put a hold on a workflow when submitted to a Cromwell server.')
 
+    # run
+    parent_run = argparse.ArgumentParser(add_help=False)
+    parent_run.add_argument(
+        '-m', '--metadata-output',
+        help='An optional directory path to output metadata JSON file')
+
     parent_submit.add_argument(
         '--deepcopy', action='store_true',
         help='Deepcopy for JSON (.json), TSV (.tsv) and CSV (.csv) '
@@ -338,7 +344,7 @@ def parse_caper_arguments():
 
     p_run = subparser.add_parser(
         'run', help='Run a single workflow without server',
-        parents=[parent_submit, parent_host, parent_backend])
+        parents=[parent_submit, parent_run, parent_host, parent_backend])
     p_server = subparser.add_parser(
         'server', help='Run a Cromwell server',
         parents=[parent_server_client, parent_host, parent_backend])

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -25,69 +25,66 @@ DEFAULT_DEEPCOPY_EXT = 'json,tsv'
 DEFAULT_CAPER_CONF_CONTENTS = """[defaults]
 
 ### MySQL database settings
-#mysql_db_ip=
-#mysql_db_port=
-#mysql_db_user=cromwell
-#mysql_db_password=cromwell
+#mysql-db-ip=
+#mysql-db-port=
+#mysql-db-user=cromwell
+#mysql-db-password=cromwell
 
 ### Cromwell general settings
 #cromwell=https://github.com/broadinstitute/cromwell/releases/download/40/cromwell-40.jar
-#use_call_caching=True
-#max_concurrent_tasks=1000
-#max_concurrent_workflows=40
+#disable-call-caching=False
+#max-concurrent-tasks=1000
+#max-concurrent-workflows=40
 
 ### Cromwell server/client settings
 #ip=localhost
 #port=8000
-## HTTP auth to connect to Cromwell server
-#user=
-#password=
 
 ### backends general settings
 ## default backend
 #backend=local
-#backend_file=
+#backend-file=
 
 ### local backend
-#out_dir=
-#tmp_dir=
+#out-dir=
+#tmp-dir=
 
 ### Google Cloud Platform backend
-#gcp_prj=encode-dcc-1016
-#out_gcs_bucket=gs://encode-pipeline-test-runs/caper/out
-#tmp_gcs_bucket=gs://encode-pipeline-test-runs/caper/tmp
+#gcp-prj=encode-dcc-1016
+#out-gcs-bucket=gs://encode-pipeline-test-runs/caper/out
+#tmp-gcs-bucket=gs://encode-pipeline-test-runs/caper/tmp
 
 ### AWS backend
-#aws_batch_arn=arn:aws:batch:us-west-1:618537831167:job-queue/first-run-job-queue
-#aws_region=us-west-1
-#out_s3_bucket=s3://encode-pipeline-test-runs/caper/out
-#tmp_s3_bucket=s3://encode-pipeline-test-runs/caper/tmp
-#use_gsutil_over_aws_s3=True
+#aws-batch-arn=arn:aws:batch:us-west-1:618537831167:job-queue/first-run-job-queue
+#aws-region=us-west-1
+#out-s3-bucket=s3://encode-pipeline-test-runs/caper/out
+#tmp-s3-bucket=s3://encode-pipeline-test-runs/caper/tmp
+#use-gsutil-over-aws-s3=True
 
 ### HTTP auth to download from URLs (http://, https://)
-#http_user=
-#http_password=
+#http-user=
+#http-password=
 
 ### SLURM backend
-#slurm_partition=akundaje
-#slurm_account=akundaje
-#slurm_extra_param=
+#slurm-partition=akundaje
+#slurm-account=akundaje
+#slurm-extra-param=
 
 ### SGE backend
-#sge_queue=q
-#sge_pe=shm
-#sge_extra_param=
+#sge-queue=q
+#sge-pe=shm
+#sge-extra-param=
 
 ### PBS backend
-#pbs_queue=q
-#pbs_extra_param=
+#pbs-queue=q
+#pbs-extra-param=
 
 ### Workflow settings
 ## deepcopy recursively all file URIs in a file URI
 ##  with supported extensions (json,tsv,csv)
 ##  to a target remote/local storage
 #deepcopy=True
-#deepcopy_ext=json,tsv
+#deepcopy-ext=json,tsv
 
 ## Put a hold on submitted jobs.
 ## You need to run "caper unhold [WORKFLOW_ID]" to release hold
@@ -127,7 +124,9 @@ def parse_caper_arguments():
         if os.path.exists(known_args.conf):
             config = ConfigParser()
             config.read([known_args.conf])
-            defaults.update(dict(config.items("defaults")))
+            d = dict(config.items("defaults"))
+            # replace - with _
+            defaults.update({k.replace('-', '_'): v for k, v in d.items()})
 
     parser = argparse.ArgumentParser(parents=[conf_parser])
     subparser = parser.add_subparsers(dest='action')
@@ -170,18 +169,12 @@ def parse_caper_arguments():
         help='Number of concurrent workflows. '
              '"system.max-concurrent-workflows" in backend configuration')
     group_cromwell.add_argument(
-        '--use-call-caching', action='store_true',
-        help='Use Cromwell\'s call caching, which re-uses outputs from '
-             'previous workflows. Make sure to configure MySQL correctly to '
-             'use this feature')
+        '--disable-call-caching', action='store_true',
+        help='Disable Cromwell\'s call caching, which re-uses outputs from '
+             'previous workflows')
     group_cromwell.add_argument(
         '--backend-file',
         help='Custom Cromwell backend configuration file to override all')
-    # group_cromwell.add_argument(
-    #     '--keep-temp-backend-file', action='store_true',
-    #     help='Keep backend.conf file in a temporary directory. '
-    #     '(SECURITY WARNING) MySQL database username/password will be '
-    #     'exposed in the temporary backend.conf file')
 
     group_local = parent_host.add_argument_group(
         title='local backend arguments')
@@ -331,12 +324,6 @@ def parse_caper_arguments():
     parent_client.add_argument(
         '--ip', default=DEFAULT_IP,
         help='IP address for Caper server')
-    parent_client.add_argument(
-        '--user',
-        help='Username for HTTP auth to connect to Cromwell server')
-    parent_client.add_argument(
-        '--password',
-        help='Password for HTTP auth to connect to Cromwell server')
     parent_list = argparse.ArgumentParser(add_help=False)
     parent_list.add_argument(
         '-f', '--format', default=DEFAULT_FORMAT,
@@ -386,9 +373,9 @@ def parse_caper_arguments():
     # convert to dict
     args_d = vars(args)
 
-    use_call_caching = args_d.get('use_call_caching')
-    if use_call_caching is not None and isinstance(use_call_caching, str):
-        args_d['use_call_caching'] = bool(strtobool(use_call_caching))
+    disable_call_caching = args_d.get('disable_call_caching')
+    if disable_call_caching is not None and isinstance(disable_call_caching, str):
+        args_d['disable_call_caching'] = bool(strtobool(disable_call_caching))
 
     use_gsutil_over_aws_s3 = args_d.get('use_gsutil_over_aws_s3')
     if use_gsutil_over_aws_s3 is not None and isinstance(use_gsutil_over_aws_s3, str):

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -36,20 +36,20 @@ class CaperBackendCommon(dict):
             "max-concurrent-workflows": 40
         },
         "call-caching": {
-            "enabled": False,
+            "enabled": True,
             "invalidate-bad-cache-results": True
         }
     }
 
-    def __init__(self, port=None, use_call_caching=None,
+    def __init__(self, port=None, disable_call_caching=None,
                  max_concurrent_workflows=None):
         super(CaperBackendCommon, self).__init__(
             CaperBackendCommon.TEMPLATE)
         if port is not None:
             self['webservice']['port'] = port
-        if use_call_caching is not None:
-            self['call-caching']['enabled'] = use_call_caching
-        if use_call_caching is not None:
+        if disable_call_caching is not None:
+            self['call-caching']['enabled'] = not disable_call_caching
+        if max_concurrent_workflows is not None:
             self['system']['max-concurrent-workflows'] = \
                 max_concurrent_workflows
 

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -315,11 +315,11 @@ class CaperBackendSLURM(dict):
         config = self['backend']['providers'][BACKEND_SLURM]['config']
         key = 'default-runtime-attributes'
 
-        if partition is not None:
+        if partition is not None and partition != '':
             config[key]['slurm_partition'] = partition
-        if account is not None:
+        if account is not None and account != '':
             config[key]['slurm_account'] = account
-        if extra_param is not None:
+        if extra_param is not None and extra_param != '':
             config[key]['slurm_extra_param'] = extra_param
         if concurrent_job_limit is not None:
             config['concurrent-job-limit'] = concurrent_job_limit
@@ -402,11 +402,11 @@ ${true=")m" false="" defined(memory_mb)} \
         config = self['backend']['providers'][BACKEND_SGE]['config']
         key = 'default-runtime-attributes'
 
-        if pe is not None:
+        if pe is not None and pe != '':
             config[key]['sge_pe'] = pe
-        if queue is not None:
+        if queue is not None and queue != '':
             config[key]['sge_queue'] = queue
-        if extra_param is not None:
+        if extra_param is not None and extra_param != '':
             config[key]['sge_extra_param'] = extra_param
         if concurrent_job_limit is not None:
             config['concurrent-job-limit'] = concurrent_job_limit
@@ -475,9 +475,9 @@ ${true=":0:0" false="" defined(time)} \
         config = self['backend']['providers'][BACKEND_PBS]['config']
         key = 'default-runtime-attributes'
 
-        if queue is not None:
+        if queue is not None and queue != '':
             config[key]['pbs_queue'] = queue
-        if extra_param is not None:
+        if extra_param is not None and extra_param != '':
             config[key]['pbs_extra_param'] = extra_param
         if concurrent_job_limit is not None:
             config['concurrent-job-limit'] = concurrent_job_limit

--- a/docs/parameters.tsv
+++ b/docs/parameters.tsv
@@ -1,0 +1,68 @@
+Cmd. line arg.	Description		
+--inputs, -i	Workflow inputs JSON file		
+--options, -o	Workflow options JSON file		
+--labels, -l	Workflow labels JSON file		
+--imports, -p	Zip file of imported subworkflows		
+			
+Cmd. line arg.	Description		
+--str-label, -s	Caper's special label for a workflow. This will be used to identify a workflow submitted by Caper		
+--docker	Docker image URI for a WDL		
+--singularity	Singaularity image URI for a WDL		
+--use-docker	Use docker image for all tasks in a workflow by adding docker URI into docker runtime-attribute		
+--use-singularity	Use singularity image for all tasks in a workflow		
+			
+Conf. file	Cmd. line arg.	Default	Description
+backend	-b, --backend	local	Caper's built-in backend to run a workflow. Supported backends: `local`, `gcp`, `aws`, `slurm`, `sge` and `pbs`. Make sure to configure for chosen backend
+hold	--hold		Put a hold on a workflow when submitted to a Cromwell server
+deepcopy	--deepcopy		Deepcopy input files to corresponding file local/remote storage
+deepcopy-ext	--deepcopy-ext	json,tsv	Comma-separated list of file extensions to be deepcopied. Supported exts: .json, .tsv  and .csv.
+format	--format, -f	id,status,name,str_label,submission	Comma-separated list of items to be shown for `list` subcommand. Supported formats: `id` (workflow UUID), `status`, `name` (WDL basename), `str_label` (Caper's special string label), `submission`, `start`, `end`
+			
+Conf. file	Cmd. line arg.	Default	Description
+out-dir	--out-dir	`$CWD`	Output directory for local backend
+tmp-dir	--tmp-dir	`$CWD/caper_tmp`	Tmp. directory for local backend
+			
+Conf. file	Cmd. line arg.	Default	Description
+gcp-prj	--gcp-prj		Google Cloud project
+out-gcs-bucket	--out-gcs-bucket		Output GCS bucket for GC backend
+tmp-gcs-bucket	--tmp-gcs-bucket		Tmp. GCS bucket for GC backend
+			
+Conf. file	Cmd. line arg.	Default	Description
+aws-batch-arn	--aws-batch-arn		ARN for AWS Batch
+aws-region	--aws-region		AWS region (e.g. us-west-1)
+out-s3-bucket	--out-s3-bucket		Output S3 bucket for AWS backend
+tmp-s3-bucket	--tmp-s3-bucket		Tmp. S3 bucket for AWS backend
+use-gsutil-over-aws-s3	--use-gsutil-over-aws-s3		Use `gsutil` instead of `aws s3` even for S3 buckets
+			
+Conf. file	Cmd. line arg.	Default	Description
+http-user	--http-user		HTTP Auth username to download data from private URLs
+http-password	--http-password		HTTP Auth password to download data from private URLs
+			
+Conf. file	Cmd. line arg.	Default	Description
+mysql-db-ip	--mysql-db-ip	localhost	MySQL DB IP address
+mysql-db-port	--mysql-db-port	3306	MySQL DB port
+mysql-db-user	--mysql-db-user	cromwell	MySQL DB username
+mysql-db-password	--mysql-db-password	cromwell	MySQL DB password
+			
+Conf. file	Cmd. line arg.	Default	Description
+ip	--ip	localhost	Cromwell server IP address or hostname
+port	--port	8000	Cromwell server port
+cromwell	--cromwell	[cromwell-40.jar](https://github.com/broadinstitute/cromwell/releases/download/40/cromwell-40.jar)	Path or URL for Cromwell JAR file
+max-concurrent-tasks	--max-concurrent-tasks	1000	Maximum number of concurrent tasks
+max-concurrent-workflows	--max-concurrent-workflows	40	Maximum number of concurrent workflows
+disable-call-caching	--disable-call-caching		Disable Cromwell's call-caching (re-using outputs)
+backend-file	--backend-file		Custom Cromwell backend conf file. This will override Caper's built-in backends
+			
+Conf. file	Cmd. line arg.	Default	Description
+slurm-partition	--slurm-partition		SLURM partition
+slurm-account	--slurm-account		SLURM account
+slurm-extra-param	--slurm-extra-param		Extra parameters for SLURM `sbatch` command
+			
+Conf. file	Cmd. line arg.	Default	Description
+sge-pe	--sge-pe		SGE parallel environment. Check with `qconf -spl`
+sge-queue	--sge-queue		SGE queue to submit tasks. Check with `qconf -sql`
+slurm-extra-param	--slurm-extra-param		Extra parameters for SGE `qsub` command
+			
+Conf. file	Cmd. line arg.	Default	Description
+pbs-queue	--pbs-queue		PBS queue to submit tasks.
+pbs-extra-param	--pbs-extra-param		Extra parameters for PBS `qsub` command

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='caper',
-    version='v0.1.2.3',
+    version='v0.1.2.4',
+    python_requires='>3.4.1',
     scripts=['bin/caper', 'mysql/run_mysql_server_docker.sh',
              'mysql/run_mysql_server_singularity.sh'],
     author='Jin Lee',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='caper',
-    version='v0.1.2.4',
+    version='v0.1.3',
     python_requires='>3.4.1',
     scripts=['bin/caper', 'mysql/run_mysql_server_docker.sh',
              'mysql/run_mysql_server_singularity.sh'],

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
     ],
-    install_requires=['pyhocon']
+    install_requires=['pyhocon', 'requests']
 )


### PR DESCRIPTION
* bug fix
    - caper_uri: typo in URL -> S3 transfer command
* URL to cloud transfer is two-step
    - URL to local and then local to cloud (gcs, s3)
* use call-caching by default
* can use both _ and - in a configuration file
* added `-m` to specify metadata JSON file destination
* fix Java heap memory for `run` (1G) and `server` (2G)
