### PR TITLE
Thread safe inter-storage file transfer

### DIFF
--- a/caper/caper.py
+++ b/caper/caper.py
@@ -482,23 +482,6 @@ class Caper(object):
                   str(e), workflow_ids)
         return False
 
-    # @staticmethod
-    # def __troubleshoot_from_cromwell_stdout(stdout):
-    #     """Troubleshoot from STDOUT of Cromwell
-    #     """
-    #     for line in stdout.strip('\n').split('\n'):
-    #         # File DB error due to locked DB file
-    #         r = re.findall(Caper.RE_PATTERN_DB_ERROR, line)
-    #         if len(r) > 0:
-    #             print('[Caper] troubleshoot: DB file is locked. '
-    #                   'Did you try to run (caper run) multiple workflows '
-    #                   'with the same file DB (--file-db)? '
-    #                   'Try with a different --file-db. Or try without file DB'
-    #                   ' (--no-file-db).'
-    #                   'But you will not be able to re-use cached results '
-    #                   'without a file DB.')
-    #     return
-
     @staticmethod
     def __troubleshoot(metadata_json, show_completed_task=False):
         """Troubleshoot from metadata JSON obj/file
@@ -551,7 +534,8 @@ class Caper(object):
                         run_start = None
                         run_end = None
 
-                    if not show_completed_task and task_status in ('Done', 'Succeeded'):
+                    if not show_completed_task and \
+                            task_status in ('Done', 'Succeeded'):
                         continue
                     print('\n{} {}. SHARD_IDX={}, RC={}, JOB_ID={}, '
                           'RUN_START={}, RUN_END={}, '
@@ -565,7 +549,8 @@ class Caper(object):
                             local_stderr_f = cu.get_local_file()
                             with open(local_stderr_f, 'r') as fp:
                                 stderr_contents = fp.read()
-                            print('STDERR_CONTENTS=\n{}'.format(stderr_contents))
+                            print('STDERR_CONTENTS=\n{}'.format(
+                                stderr_contents))
 
         calls = metadata['calls']
         failures = metadata['failures'] if 'failures' in metadata else None

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -519,7 +519,8 @@ def parse_caper_arguments():
         args_d['use_netrc'] = bool(strtobool(use_netrc))
 
     show_completed_task = args_d.get('show_completed_task')
-    if show_completed_task is not None and isinstance(show_completed_task, str):
+    if show_completed_task is not None and \
+            isinstance(show_completed_task, str):
         args_d['show_completed_task'] = bool(strtobool(show_completed_task))
 
     # int string to int

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -84,8 +84,9 @@ class CaperBackendDatabase(dict):
             db = self['database']['db']
             db['user'] = mysql_user
             db['password'] = mysql_password
-            db['url'] = db['url'].replace('localhost:3306', '{ip}:{port}'.format(
-                ip=mysql_ip, port=mysql_port))
+            db['url'] = db['url'].replace(
+                'localhost:3306', '{ip}:{port}'.format(
+                    ip=mysql_ip, port=mysql_port))
         else:
             self['database'] = {}
             if file_db is not None:
@@ -94,6 +95,7 @@ class CaperBackendDatabase(dict):
                     'hsqldb.tx=mvcc'.format(file_db)
                 }
 
+
 class CaperBackendGCP(dict):
     """Google Cloud backend
     """
@@ -101,8 +103,8 @@ class CaperBackendGCP(dict):
         "backend": {
             "providers": {
                 BACKEND_GCP: {
-                    "actor-factory": "cromwell.backend.google.pipelines.v1alpha2."
-                    "PipelinesApiLifecycleActorFactory",
+                    "actor-factory": "cromwell.backend.google.pipelines."
+                    "v1alpha2.PipelinesApiLifecycleActorFactory",
                     "config": {
                         "default-runtime-attributes": {
                         },

--- a/caper/caper_uri.py
+++ b/caper/caper_uri.py
@@ -269,7 +269,7 @@ class CaperURI(object):
             # if target file not exists or file sizes are different
             # then do copy!
             if not cu_target.file_exists() or \
-                     self.get_file_size() != cu_target.get_file_size():
+                    self.get_file_size() != cu_target.get_file_size():
 
                 action = 'done'
                 cu_lock = CaperURI(path + CaperURI.LOCK_EXT)
@@ -283,10 +283,12 @@ class CaperURI(object):
 
                     elif uri_type == URI_GCS:
                         if self._uri_type == URI_URL:
-                            tmp_local_f = CaperURI(self._uri).get_file(uri_type=URI_LOCAL)
+                            tmp_local_f = CaperURI(self._uri).get_file(
+                                uri_type=URI_LOCAL)
                             CaperURI(tmp_local_f).copy(target_uri=path)
 
-                        elif self._uri_type == URI_GCS or self._uri_type == URI_S3 \
+                        elif self._uri_type == URI_GCS or \
+                                self._uri_type == URI_S3 \
                                 or self._uri_type == URI_LOCAL:
                             check_call(['gsutil', '-q', 'cp', self._uri, path])
                         else:
@@ -294,17 +296,21 @@ class CaperURI(object):
 
                     elif uri_type == URI_S3:
                         if self._uri_type == URI_URL:
-                            tmp_local_f = CaperURI(self._uri).get_file(uri_type=URI_LOCAL)
+                            tmp_local_f = CaperURI(self._uri).get_file(
+                                uri_type=URI_LOCAL)
                             CaperURI(tmp_local_f).copy(target_uri=path)
 
                         elif self._uri_type == URI_GCS:
                             check_call(['gsutil', '-q', 'cp', self._uri, path])
 
-                        elif self._uri_type == URI_S3 or self._uri_type == URI_LOCAL:
+                        elif self._uri_type == URI_S3 or \
+                                self._uri_type == URI_LOCAL:
                             if CaperURI.USE_GSUTIL_OVER_AWS_S3:
-                                check_call(['gsutil', '-q', 'cp', self._uri, path])
+                                check_call(['gsutil', '-q', 'cp',
+                                            self._uri, path])
                             elif not CaperURI.__file_exists(path):
-                                check_call(['aws', 's3', 'cp', '--only-show-errors',
+                                check_call(['aws', 's3', 'cp',
+                                            '--only-show-errors',
                                             self._uri, path])
                         else:
                             path = None
@@ -327,8 +333,8 @@ class CaperURI(object):
 
                         elif self._uri_type == URI_URL:
                             # we need "curl -C -" to resume downloading
-                            # but it always fails with HTTP ERR 416 when file is
-                            # already fully downloaded, i.e. path exists
+                            # but it always fails with HTTP ERR 416 when file
+                            # is already fully downloaded, i.e. path exists
                             _, _, _, http_err = CaperURI.__curl_auto_auth(
                                 ['curl', '-RL', '-f', '-C', '-',
                                  self._uri, '-o', path],
@@ -342,13 +348,15 @@ class CaperURI(object):
                             check_call(['gsutil', '-q', 'cp', self._uri, path])
                         elif self._uri_type == URI_S3:
                             if not CaperURI.__file_exists(path):
-                                check_call(['aws', 's3', 'cp', '--only-show-errors',
+                                check_call(['aws', 's3', 'cp',
+                                            '--only-show-errors',
                                             self._uri, path])
                         else:
                             path = None
 
                     else:
-                        raise NotImplementedError('uri_type: {}'.format(uri_type))
+                        raise NotImplementedError('uri_type: {}'.format(
+                            uri_type))
 
                     if path is None:
                         raise NotImplementedError('uri_types: {}, {}'.format(
@@ -646,7 +654,7 @@ class CaperURI(object):
 
         elif self._uri_type == URI_S3:
             return check_call(['aws', 's3', 'rm', '--only-show-errors',
-                                 self._uri])
+                               self._uri])
 
         elif self._uri_type == URI_LOCAL:
             os.remove(self._uri)

--- a/caper/caper_uri.py
+++ b/caper/caper_uri.py
@@ -10,6 +10,7 @@ import os
 import errno
 import json
 import shutil
+import time
 import hashlib
 from copy import deepcopy
 from collections import OrderedDict
@@ -92,6 +93,10 @@ class CaperURI(object):
     CURL_HTTP_ERROR_PREFIX = '_CaperURI_HTTP_ERROR_'
     CURL_HTTP_ERROR_WRITE_OUT = CURL_HTTP_ERROR_PREFIX + '%{http_code}'
     RE_PATTERN_CURL_HTTP_ERR = r'_CaperURI_HTTP_ERROR_(\d*)'
+
+    LOCK_EXT = '.lock'
+    LOCK_WAIT_SEC = 30
+    LOCK_MAX_ITER = 100
 
     def __init__(self, uri_or_path):
         if CaperURI.TMP_DIR is None:
@@ -183,7 +188,7 @@ class CaperURI(object):
 
         Args:
             target_uri_type, target_uri:
-                these are exclusive. Specify only one of them.
+                these are mutually exclusive. Specify only one of them.
 
             soft_link:
                 soft link target if possible. e.g. from local to local
@@ -215,8 +220,10 @@ class CaperURI(object):
                     method=method,
                     src=self._uri_type, target=uri_type, uri=self._uri))
 
+        # here, path is target path
+        # get target path
         if uri_type == URI_URL:
-            if path is not None:
+            if path is not None:  # since URL is readonly
                 path = None
             elif self._uri_type == URI_GCS:
                 path = 'http://storage.googleapis.com/{}'.format(
@@ -229,91 +236,130 @@ class CaperURI(object):
             if path is None:
                 path = self.__get_gcs_file_name()
 
-            if no_copy:
-                pass
-            elif self._uri_type == URI_URL:
-                tmp_local_f = CaperURI(self._uri).get_file(uri_type=URI_LOCAL)
-                CaperURI(tmp_local_f).copy(target_uri=path)
-
-            elif self._uri_type == URI_GCS or self._uri_type == URI_S3 \
-                    or self._uri_type == URI_LOCAL:
-                check_call(['gsutil', '-q', 'cp', '-n', self._uri, path])
-            else:
-                path = None
-
         elif uri_type == URI_S3:
             if path is None:
                 path = self.__get_s3_file_name()
-
-            if no_copy:
-                pass
-            elif self._uri_type == URI_URL:
-                tmp_local_f = CaperURI(self._uri).get_file(uri_type=URI_LOCAL)
-                CaperURI(tmp_local_f).copy(target_uri=path)
-
-            elif self._uri_type == URI_GCS:
-                check_call(['gsutil', '-q', 'cp', '-n', self._uri, path])
-
-            elif self._uri_type == URI_S3 or self._uri_type == URI_LOCAL:
-                if CaperURI.USE_GSUTIL_OVER_AWS_S3:
-                    check_call(['gsutil', '-q', 'cp', '-n', self._uri, path])
-                elif not CaperURI.__file_exists(path):
-                    check_call(['aws', 's3', 'cp', '--only-show-errors',
-                                self._uri, path])
-            else:
-                path = None
 
         elif uri_type == URI_LOCAL:
             if path is None:
                 path = self.__get_local_file_name()
             os.makedirs(os.path.dirname(path), exist_ok=True)
 
-            if no_copy:
-                pass
-            elif self._uri_type == URI_LOCAL:
-                if soft_link:
-                    if CaperURI.VERBOSE:
-                        method = 'symlinking'
-                    try:
-                        os.symlink(self._uri, path)
-                    except OSError as e:
-                        if e.errno == errno.EEXIST:
-                            os.remove(path)
-                            os.symlink(self._uri, path)
-                else:
-                    if CaperURI.VERBOSE:
-                        method = 'copying'
-                    shutil.copy2(self._uri, path)
-
-            elif self._uri_type == URI_URL:
-                # we need "curl -C -" to resume downloading
-                # but it always fails with HTTP ERR 416 when file is
-                # already fully downloaded, i.e. path exists
-                CaperURI.__curl_auto_auth(
-                    ['curl', '-RL', '-f', '-C', '-',
-                     self._uri, '-o', path],
-                    ignored_http_err=(416,))
-
-            elif self._uri_type == URI_GCS or \
-                self._uri_type == URI_S3 and \
-                    CaperURI.USE_GSUTIL_OVER_AWS_S3:
-                check_call(['gsutil', '-q', 'cp', '-n', self._uri, path])
-            elif self._uri_type == URI_S3:
-                if not CaperURI.__file_exists(path):
-                    check_call(['aws', 's3', 'cp', '--only-show-errors',
-                                self._uri, path])
-            else:
-                path = None
-
         else:
             raise NotImplementedError('uri_type: {}'.format(uri_type))
 
-        if path is None:
-            raise NotImplementedError('uri_types: {}, {}'.format(
-                self._uri_type, uri_type))
+        action = 'skipped'
+        if not no_copy:
+            assert(path is not None)
+            # wait until .lock file disappears
+            it = 0
+            cu_lock = CaperURI(path + CaperURI.LOCK_EXT)
+            while cu_lock.file_exists():
+                it += 1
+                if it > CaperURI.LOCK_MAX_ITER:
+                    raise Exception('File has been locked for too long.', path)
+                elif CaperURI.VERBOSE:
+                    print('[CaperURI] wait {} sec for file being unlocked. '
+                          'retries: {}, max_retries: {}. uri: {}'.format(
+                            CaperURI.LOCK_WAIT_SEC, it,
+                            CaperURI.LOCK_MAX_ITER, path))
+                time.sleep(CaperURI.LOCK_WAIT_SEC)
+
+            cu_target = CaperURI(path)
+            # if target file not exists or file sizes are different
+            # then do copy!
+            if not cu_target.file_exists() or \
+                     self.get_file_size() != cu_target.get_file_size():
+
+                action = 'done'
+                cu_lock = CaperURI(path + CaperURI.LOCK_EXT)
+                try:
+                    # create an empty .lock file
+                    cu_lock.write_str_to_file('', quiet=True)
+
+                    # do copy
+                    if uri_type == URI_URL:
+                        pass
+
+                    elif uri_type == URI_GCS:
+                        if self._uri_type == URI_URL:
+                            tmp_local_f = CaperURI(self._uri).get_file(uri_type=URI_LOCAL)
+                            CaperURI(tmp_local_f).copy(target_uri=path)
+
+                        elif self._uri_type == URI_GCS or self._uri_type == URI_S3 \
+                                or self._uri_type == URI_LOCAL:
+                            check_call(['gsutil', '-q', 'cp', self._uri, path])
+                        else:
+                            path = None
+
+                    elif uri_type == URI_S3:
+                        if self._uri_type == URI_URL:
+                            tmp_local_f = CaperURI(self._uri).get_file(uri_type=URI_LOCAL)
+                            CaperURI(tmp_local_f).copy(target_uri=path)
+
+                        elif self._uri_type == URI_GCS:
+                            check_call(['gsutil', '-q', 'cp', self._uri, path])
+
+                        elif self._uri_type == URI_S3 or self._uri_type == URI_LOCAL:
+                            if CaperURI.USE_GSUTIL_OVER_AWS_S3:
+                                check_call(['gsutil', '-q', 'cp', self._uri, path])
+                            elif not CaperURI.__file_exists(path):
+                                check_call(['aws', 's3', 'cp', '--only-show-errors',
+                                            self._uri, path])
+                        else:
+                            path = None
+
+                    elif uri_type == URI_LOCAL:
+                        if self._uri_type == URI_LOCAL:
+                            if soft_link:
+                                if CaperURI.VERBOSE:
+                                    method = 'symlinking'
+                                try:
+                                    os.symlink(self._uri, path)
+                                except OSError as e:
+                                    if e.errno == errno.EEXIST:
+                                        os.remove(path)
+                                        os.symlink(self._uri, path)
+                            else:
+                                if CaperURI.VERBOSE:
+                                    method = 'copying'
+                                shutil.copy2(self._uri, path)
+
+                        elif self._uri_type == URI_URL:
+                            # we need "curl -C -" to resume downloading
+                            # but it always fails with HTTP ERR 416 when file is
+                            # already fully downloaded, i.e. path exists
+                            _, _, _, http_err = CaperURI.__curl_auto_auth(
+                                ['curl', '-RL', '-f', '-C', '-',
+                                 self._uri, '-o', path],
+                                ignored_http_err=(416,))
+                            if http_err in (416,):
+                                action = 'skipped'
+
+                        elif self._uri_type == URI_GCS or \
+                            self._uri_type == URI_S3 and \
+                                CaperURI.USE_GSUTIL_OVER_AWS_S3:
+                            check_call(['gsutil', '-q', 'cp', self._uri, path])
+                        elif self._uri_type == URI_S3:
+                            if not CaperURI.__file_exists(path):
+                                check_call(['aws', 's3', 'cp', '--only-show-errors',
+                                            self._uri, path])
+                        else:
+                            path = None
+
+                    else:
+                        raise NotImplementedError('uri_type: {}'.format(uri_type))
+
+                    if path is None:
+                        raise NotImplementedError('uri_types: {}, {}'.format(
+                            self._uri_type, uri_type))
+                finally:
+                    # remove .lock file
+                    cu_lock.rm(quiet=True)
+
         if CaperURI.VERBOSE:
-            print('[CaperURI] {method} done, target: {target}'.format(
-                    method=method, target=path))
+            print('[CaperURI] {method} {action}, target: {target}'.format(
+                    method=method, action=action, target=path))
         return path
 
     def get_file_contents(self):
@@ -343,8 +389,35 @@ class CaperURI(object):
             raise NotImplementedError('uri_type: {}'.format(
                 self._uri_type))
 
-    def write_str_to_file(self, s):
-        if CaperURI.VERBOSE:
+    def get_file_size(self):
+        """Get file size
+        Returns:
+            File size in bytes or None (for all URLS,
+                hard to estimate file size for redirected URLs)
+        """
+        if self._uri_type == URI_URL:
+            return None
+
+        elif self._uri_type == URI_GCS or self._uri_type == URI_S3 \
+                and CaperURI.USE_GSUTIL_OVER_AWS_S3:
+            s = check_output(['gsutil', '-q', 'ls', '-l', self._uri]).decode()
+            # example ['1000982', '2019-05-21T21:06:47Z', ...]
+            return int(s.strip('\n').split()[0])
+
+        elif self._uri_type == URI_S3:
+            s = check_output(['aws', 's3', 'ls', self._uri]).decode()
+            # example ['2019-05-21', '14:06:47', '1000982', 'x.txt']
+            return int(s.strip('\n').split()[2])
+
+        elif self._uri_type == URI_LOCAL:
+            return os.path.getsize(self._uri)
+
+        else:
+            raise NotImplementedError('uri_type: {}'.format(
+                self._uri_type))
+
+    def write_str_to_file(self, s, quiet=False):
+        if CaperURI.VERBOSE and not quiet:
             print('[CaperURI] write to '
                   '{target}, target: {uri}, size: {size}'.format(
                     target=self._uri_type, uri=self._uri, size=len(s)))
@@ -562,6 +635,25 @@ class CaperURI(object):
                 NotImplementedError('ext: {}.'.format(ext))
         return self
 
+    def rm(self, quiet=False):
+        """Remove file
+        """
+        if CaperURI.VERBOSE and not quiet:
+            print('[CaperURI] remove {}'.format(self._uri))
+        if self._uri_type == URI_GCS or self._uri_type == URI_S3 \
+                and CaperURI.USE_GSUTIL_OVER_AWS_S3:
+            return check_call(['gsutil', '-q', 'rm', self._uri])
+
+        elif self._uri_type == URI_S3:
+            return check_call(['aws', 's3', 'rm', '--only-show-errors',
+                                 self._uri])
+
+        elif self._uri_type == URI_LOCAL:
+            os.remove(self._uri)
+        else:
+            raise NotImplementedError('uri_type: {}'.format(
+                self._uri_type))
+
     @staticmethod
     def __get_uri_type(uri):
         if uri.startswith(('http://', 'https://', 'ftp://')):
@@ -625,12 +717,7 @@ class CaperURI(object):
                     stdout.split(CaperURI.CURL_HTTP_ERROR_PREFIX)[:-1])
             else:
                 http_err = None
-            # if rc > 0:
-            #     m = re.findall(CaperURI.RE_PATTERN_CURL_HTTP_ERR,
-            #                    stderr)
-            #     http_err = int(m[0]) if len(m) > 0 else None
-            # else:
-            #     http_err = None
+
             if CaperURI.HTTP_USER is None and not CaperURI.USE_NETRC:
                 # if auth info is not given
                 pass
@@ -663,12 +750,6 @@ class CaperURI(object):
                                 CaperURI.CURL_HTTP_ERROR_WRITE_OUT)[:-1])
                 else:
                     http_err = None
-                # if rc > 0:
-                #     m = re.findall(CaperURI.RE_PATTERN_CURL_HTTP_ERR,
-                #                    stderr)
-                #     http_err = int(m[0]) if len(m) > 0 else None
-                # else:
-                #     http_err = None
 
         except CalledProcessError as e:
             stdout = None

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='caper',
-    version='v0.2.8',
+    version='v0.3.0',
     python_requires='>3.4.1',
     scripts=['bin/caper', 'mysql/run_mysql_server_docker.sh',
              'mysql/run_mysql_server_singularity.sh'],


### PR DESCRIPTION
* thread safe inter-storage file transfer
  - added a simple spin lock (with `.lock` file) to obtain thread safety for file transfer
    - multiple users can share the same `tmp-dir`, `tmp-s3-bucket` and `tmp-gs-bucket`.
  - limitation
    - possible race condition
    - skip copying only if file size of source and target files are same (does not check md5sum)
    - source files are not locked to prevent deadlock
      - make sure that source files are almost like read-only