### PR TITLE
Dev10

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -6,7 +6,7 @@
 
 * **Automatic transfer between local/cloud storages**: You can use URIs (e.g. `gs://`, `http(s)://` and `s3://`) instead of paths in a command line arguments, also in your input JSON file. Files associated with these URIs will be automatically transfered to a specified temporary directory on a target remote storage.
 
-* **Deepcopy for input JSON file**: Recursively copy all data files in (`.json`, `.tsv` and `.csv`) to a target remote storage. Use `--deepcopy` for this feature.
+* **Deepcopy for input JSON file**: Recursively copy all data files in (`.json`, `.tsv` and `.csv`) to a target remote storage. It's activate by default. Use `--no-deepcopy` to disable this feature.
 
 * **Docker/Singularity integration**: You can run a WDL workflow in a specifed docker/singularity container.
 
@@ -55,13 +55,13 @@ We highly recommend to use a default configuration file described in the section
 	--java-heap-server|Java heap memory for caper server (default: 7GB)
 	--java-heap-run|Java heap memory for caper run (default: 1GB)
 
-* Choose a default backend. Use `--deepcopy` to recursively auto-copy data files in your input JSON file. All data files will be automatically transferred to a target local/remote storage corresponding to a chosen backend. Make sure that you correctly configure temporary directories for source/target storages (`--tmp-dir`, `--tmp-gcs-bucket` and `--tmp-s3-bucket`).
+* Choose a default backend. Deepcopy is enabled by default. All data files will be automatically transferred to a target local/remote storage corresponding to a chosen backend. Make sure that you correctly configure temporary directories for source/target storages (`--tmp-dir`, `--tmp-gcs-bucket` and `--tmp-s3-bucket`). To disable this feature use `--no-deepcopy`.
 
 	**Conf. file**|**Cmd. line**|**Default**|**Description**
 	:-----|:-----|:-----|:-----
 	backend|-b, --backend|local|Caper's built-in backend to run a workflow. Supported backends: `local`, `gcp`, `aws`, `slurm`, `sge` and `pbs`. Make sure to configure for chosen backend
 	hold|--hold| |Put a hold on a workflow when submitted to a Cromwell server
-	deepcopy|--deepcopy| |Deepcopy input files to corresponding file local/remote storage
+	no-deepcopy|--no-deepcopy| |Disable deepcopy (copying files defined in an input JSON to corresponding file local/remote storage)
 	deepcopy-ext|--deepcopy-ext|json,<br>tsv|Comma-separated list of file extensions to be deepcopied. Supported exts: .json, .tsv  and .csv.
 	format|--format, -f|id,status,<br>name,<br>str_label,<br>submission|Comma-separated list of items to be shown for `list` subcommand. Supported formats: `id` (workflow UUID), `status`, `name` (WDL basename), `str\_label` (Caper's special string label), `submission`, `start`, `end`
 	hide-result-before|--hide-result-before| | Datetime string to hide old workflows submitted before it. This is based on a simple string sorting. (e.g. 2019-06-13, 2019-06-13T10:07)

--- a/DETAILS.md
+++ b/DETAILS.md
@@ -42,11 +42,10 @@ We highly recommend to use a default configuration file described in the section
 
 	**Cmd. line**|**Description**
 	:-----|:-----
+	--dry-run|Caper generates all temporary files but does not take any action.
 	--str-label, -s|Caper's special label for a workflow. This will be used to identify a workflow submitted by Caper
-	--docker|Docker image URI for a WDL
-	--singularity|Singularity image URI for a WDL
-	--use-docker|Use docker image for all tasks in a workflow by adding docker URI into docker runtime-attribute
-	--use-singularity|Use singularity image for all tasks in a workflow
+	--docker|Docker image URI for a WDL. You can also use this as a flag. You can also use this as a flag to use Docker image defined in your WDL as a special comment `#CAPER docker [IMAGE]`.
+	--singularity|Singularity image URI for a WDL. You can also use this as a flag to use Singularity image defined in your WDL as a special comment `#CAPER singularity [IMAGE]`.
 	--no-build-singularity|Local singularity image will not be built before running/submitting a workflow
 	--singularity-cachedir|Singularity image URI for a WDL
 	--file-db, -d|DB file for Cromwell's built-in HyperSQL database
@@ -180,10 +179,10 @@ You can also use your own MySQL database if you [configure MySQL for Caper](DETA
 
 ## Singularity
 
-Caper supports Singularity for its local built-in backend (`local`, `slurm`, `sge` and `pbs`). Tasks in a workflow will run inside a container and outputs will be pulled out to a host from it at the end of each task. Or you can add `--use-singularity` to use a [Singularity image URI defined in your WDL as a comment](DETAILS.md/#wdl-customization).
+Caper supports Singularity for its local built-in backend (`local`, `slurm`, `sge` and `pbs`). Tasks in a workflow will run inside a container and outputs will be pulled out to a host from it at the end of each task. You need to add `--singularity` to use your own Singularity image. `SINGULARITY_IMAGE_URI` is **OPTIONAL**. You can omit it then Caper will try to find a [Singularity image URI defined in your WDL as a comment](DETAILS.md/#wdl-customization).
 
 ```bash
-$ caper run [WDL] -i [INPUT_JSON] --singularity [SINGULARITY_IMAGE_URI]
+$ caper run [WDL] -i [INPUT_JSON] --singularity [SINGULARITY_IMAGE_URI_OR_LEAVE_IT_BLANK]
 ```
 
 Define a cache directory where local Singularity images will be built. You can also define an environment variable `SINGULARITY_CACHEDIR`.
@@ -198,12 +197,12 @@ Singularity image will be built first before running a workflow to prevent mutip
 
 Caper supports Docker for its non-HPC backends (`local`, `aws` and `gcp`). 
 
-> **WARNING**: AWS and GCP backends will not work without a Docker image URI defined in a WDL file or specified with `--docker`. You can skip adding `--use-docker` since Caper will try to find it in your WDL first.
+> **WARNING**: For `aws` and `gcp` backends Caper will try to find a [Docker image URI defined in your WDL as a comment](DETAILS.md/#wdl-customization) even if `--docker` is not explicitly defined.
 
-Tasks in a workflow will run inside a container and outputs will be pulled out to a host from it at the end of each task. Or you can add `--use-docker` to use a [Docker image URI defined in your WDL as a comment](DETAILS.md/#wdl-customization).
+Tasks in a workflow will run inside a container and outputs will be pulled out to a host from it at the end of each task. `DOCKER_IMAGE_URI` is **OPTIONAL**. If it's not defined then Caper will try to find a [Docker image URI defined in your WDL as a comment](DETAILS.md/#wdl-customization).
 
 ```bash
-$ caper run [WDL] -i [INPUT_JSON] --docker [DOCKER_IMAGE_URI]
+$ caper run [WDL] -i [INPUT_JSON] --docker [DOCKER_IMAGE_URI_OR_LEAVE_IT_BLANK]
 ```
 
 ## Conda

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ Cloud backends (AWS and GCP) write outputs on corresponding storage buckets (s3 
 
 ## Deepcopy (auto inter-storage transfer)
 
-`--deepcopy` allows Caper to **RECURSIVELY** copy files defined in your input JSON into your target backend's temporary storage. For example, Cromwell cannot read directly from URLs in an [input JSON file](https://github.com/ENCODE-DCC/atac-seq-pipeline/blob/master/examples/caper/ENCSR356KRQ_subsampled.json), but Caper with `--deepcopy` makes copies of these URLs on your backend's temporary directory (e.g. `--tmp-dir` for `local`, `--tmp-gcs-bucket` for `gcp`) and pass them to Cromwell.
+> **IMPORTANT**: `--deepcopy` has been deprecated and it's activated by default. You can disable it with `--no-deepcopy`.
+
+Deepcopy allows Caper to **RECURSIVELY** copy files defined in your input JSON into your target backend's temporary storage. For example, Cromwell cannot read directly from URLs in an [input JSON file](https://github.com/ENCODE-DCC/atac-seq-pipeline/blob/master/examples/caper/ENCSR356KRQ_subsampled.json), but Caper makes copies of these URLs on your backend's temporary directory (e.g. `--tmp-dir` for `local`, `--tmp-gcs-bucket` for `gcp`) and pass them to Cromwell.
 
 ## How to manage configuration file per project
 
@@ -266,10 +268,10 @@ According to your chosen backend, define the following parameters in your defaul
 
 Run Caper. Make sure to keep your SSH session alive.
 
-`--deepcopy` is optional for input JSON file with remote URIs defined in it. Those URIs (`http(s)://`, `s3://`, `gs://`, ...) will be recursively copied into a target storage for a corresponding chosen backend. For example, GCS bucket (`gs://`) for GCP backend (`gcp`).
+Deepcopy is activate by default and URIs (`http(s)://`, `s3://`, `gs://`, ...) in your input JSON will be recursively copied into a target storage for a corresponding chosen backend. For example, GCS bucket (`gs://`) for GCP backend (`gcp`).
 
 ```bash
-$ caper run [WDL] -i [INPUT_JSON] --deepcopy
+$ caper run [WDL] -i [INPUT_JSON]
 ```
 
 Or run a Cromwell server with Caper. Make sure to keep server's SSH session alive.

--- a/README.md
+++ b/README.md
@@ -288,21 +288,21 @@ $ caper submit [WDL] -i [INPUT_JSON] --ip [SERVER_HOSTNAME] --port [PORT]
 
 On HPCs (e.g. Stanford Sherlock and SCG), you can run Caper with a Singularity container if that is [defined inside `WDL`](DETAILS.md/#wdl-customization). For example, ENCODE [ATAC-seq](https://github.com/ENCODE-DCC/atac-seq-pipeline/blob/master/atac.wdl#L5) and [ChIP-seq](https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/master/chip.wdl#L5) pipelines.
 ```bash
-$ caper run [WDL] -i [INPUT_JSON] --use-singularity
+$ caper run [WDL] -i [INPUT_JSON] --singularity
 ```
 
 Or specify your own Singularity container.
 ```bash
-$ caper run [WDL] -i [INPUT_JSON] --singularity [SINGULARITY_IMAGE_URI]
+$ caper run [WDL] -i [INPUT_JSON] --singularity [YOUR_OWN_SINGULARITY_IMAGE_URI]
 ```
 
 Similarly for Docker.
 ```bash
-$ caper run [WDL] -i [INPUT_JSON] --use-docker
+$ caper run [WDL] -i [INPUT_JSON] --docker
 ```
 
 ```bash
-$ caper run [WDL] -i [INPUT_JSON] --docker [DOCKER_IMAGE_URI]
+$ caper run [WDL] -i [INPUT_JSON] --docker [YOUR_OWN_DOCKER_IMAGE_URI]
 ```
 
 ## HPCs

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -529,7 +529,7 @@ class Caper(object):
                 path, Caper.TMP_FILE_BASENAME_METADATA_JSON)
 
         return CaperURI(metadata_uri).write_str_to_file(
-            json.dumps(metadata_json, indent=4)).get_uri()
+            json.dumps(metadata_json, indent=4))
 
     def __create_input_json_file(
             self, directory, fname='inputs.json'):
@@ -538,6 +538,7 @@ class Caper(object):
         """
         if self._inputs is not None:
             c = CaperURI(self._inputs)
+            new_uri = c.get_local_file()
             if self._deepcopy and self._deepcopy_ext:
                 # deepcopy all files in JSON/TSV/CSV
                 #   to the target backend
@@ -547,9 +548,9 @@ class Caper(object):
                     uri_type = URI_S3
                 else:
                     uri_type = URI_LOCAL
-                c = c.deepcopy(uri_type=uri_type,
-                               uri_exts=self._deepcopy_ext)
-            return c.get_local_file()
+                new_uri, _ = CaperURI(new_uri).deepcopy(
+                    uri_type=uri_type, uri_exts=self._deepcopy_ext)
+            return new_uri
         else:
             input_file = os.path.join(directory, fname)
             with open(input_file, 'w') as fp:

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -168,7 +168,7 @@ class Caper(object):
             self._backend = BACKEND_LOCAL  # Local (capital L)
 
         # deepcopy
-        self._deepcopy = args.get('deepcopy')
+        self._no_deepcopy = args.get('no_deepcopy')
         self._deepcopy_ext = args.get('deepcopy_ext')
         if self._deepcopy_ext is not None:
             self._deepcopy_ext = [
@@ -539,7 +539,7 @@ class Caper(object):
         if self._inputs is not None:
             c = CaperURI(self._inputs)
             new_uri = c.get_local_file()
-            if self._deepcopy and self._deepcopy_ext:
+            if not self._no_deepcopy and self._deepcopy_ext:
                 # deepcopy all files in JSON/TSV/CSV
                 #   to the target backend
                 if self._backend == BACKEND_GCP:
@@ -550,6 +550,7 @@ class Caper(object):
                     uri_type = URI_LOCAL
                 new_uri, _ = CaperURI(new_uri).deepcopy(
                     uri_type=uri_type, uri_exts=self._deepcopy_ext)
+
             return new_uri
         else:
             input_file = os.path.join(directory, fname)

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -405,8 +405,11 @@ def parse_caper_arguments():
         help='Cromwell Java heap size for "run" mode (java -Xmx)')
 
     parent_submit.add_argument(
-        '--deepcopy', action='store_true',
-        help='Deepcopy for JSON (.json), TSV (.tsv) and CSV (.csv) '
+        '--no-deepcopy', action='store_true',
+        help='(IMPORTANT) --deepcopy has been deprecated. '
+             'Deepcopying is now activated by default. '
+             'This flag disables deepcopy for '
+             'JSON (.json), TSV (.tsv) and CSV (.csv) '
              'files specified in an input JSON file (--inputs). '
              'Find all path/URI string values in an input JSON file '
              'and make copies of files on a local/remote storage '
@@ -578,9 +581,9 @@ def parse_caper_arguments():
     if hold is not None and isinstance(hold, str):
         args_d['hold'] = bool(strtobool(hold))
 
-    deepcopy = args_d.get('deepcopy')
-    if deepcopy is not None and isinstance(deepcopy, str):
-        args_d['deepcopy'] = bool(strtobool(deepcopy))
+    no_deepcopy = args_d.get('no_deepcopy')
+    if no_deepcopy is not None and isinstance(no_deepcopy, str):
+        args_d['no_deepcopy'] = bool(strtobool(no_deepcopy))
 
     use_docker = args_d.get('use_docker')
     if use_docker is not None and isinstance(use_docker, str):

--- a/caper/caper_uri.py
+++ b/caper/caper_uri.py
@@ -453,7 +453,7 @@ class CaperURI(object):
             p.communicate(input=s.encode('ascii'))
         else:
             raise NotImplementedError('uri_type: {}'.format(self._uri_type))
-        return self
+        return self._uri
 
     def __get_rel_uri(self):
         if self._uri_type == URI_LOCAL:
@@ -538,7 +538,7 @@ class CaperURI(object):
 
     def __deepcopy_tsv(self, uri_type=None, uri_exts=(), delim='\t'):
         if uri_type is None or len(uri_exts) == 0:
-            return self
+            return self._uri
         fname_wo_ext, ext = os.path.splitext(self._uri)
         assert(ext in ('.tsv', '.csv'))
 
@@ -550,19 +550,14 @@ class CaperURI(object):
             new_values = []
             for v in line.split(delim):
                 c = CaperURI(v)
-                if c.can_deepcopy() and c.uri_type != uri_type:
-                    updated = True
-                    if CaperURI.VERBOSE:
-                        print('[CaperURI] deepcopy_tsv from '
-                              '{src} to {tgt}, src: {uri}, tsv: {uri2}'.format(
-                                src=c._uri_type, tgt=uri_type,
-                                uri=c._uri, uri2=self._uri))
-                    # copy file to target storage
-                    new_file = c.deepcopy(uri_type=uri_type,
-                                          uri_exts=uri_exts).get_file(uri_type)
+                new_file, updated_ = c.deepcopy(
+                    uri_type=uri_type, uri_exts=uri_exts)
+                updated |= updated_
+                if updated_:
                     new_values.append(new_file)
                 else:
                     new_values.append(v)
+
             new_contents.append(delim.join(new_values))
 
         if updated:
@@ -573,13 +568,13 @@ class CaperURI(object):
             # we can't write on URLs
             if cu.uri_type == URI_URL:
                 cu.set_uri_type_no_copy(uri_type)
-            return cu.write_str_to_file(s)
+            return cu.write_str_to_file(s), updated
         else:
-            return self
+            return self._uri, updated
 
     def __deepcopy_json(self, uri_type=None, uri_exts=()):
         if uri_type is None or len(uri_exts) == 0:
-            return self
+            return self._uri
         fname_wo_ext, ext = os.path.splitext(self._uri)
         assert(ext in ('.json'))
 
@@ -595,25 +590,22 @@ class CaperURI(object):
                 for i, v in enumerate(d):
                     updated |= recurse_dict(v, uri_type, lst=d,
                                             lst_idx=i, updated=updated)
-            elif type(d) == str:
+            elif isinstance(d, str):
                 assert(d_parent is not None or lst is not None)
                 c = CaperURI(d)
-                if c.can_deepcopy() and c.uri_type != uri_type:
-                    if CaperURI.VERBOSE:
-                        print('[CaperURI] deepcopy_json from '
-                              '{src} to {tgt}, src: {uri}, json: {u2}'.format(
-                                src=c._uri_type, tgt=uri_type,
-                                uri=c._uri, u2=self._uri))
-                    new_file = c.deepcopy(
-                        uri_type=uri_type, uri_exts=uri_exts).get_file(
-                            uri_type)
+                new_file, updated_ = c.deepcopy(
+                    uri_type=uri_type, uri_exts=uri_exts)
+                updated |= updated_
+
+                if updated_:
                     if d_parent is not None:
                         d_parent[d_parent_key] = new_file
                     elif lst is not None:
                         lst[lst_idx] = new_file
                     else:
                         raise ValueError('Recursion failed.')
-                    return True
+                return updated
+
             return updated
 
         org_d = json.loads(contents, object_pairs_hook=OrderedDict)
@@ -630,25 +622,31 @@ class CaperURI(object):
             # we can't write on URLs
             if cu.uri_type == URI_URL:
                 cu.set_uri_type_no_copy(uri_type)
-            return cu.write_str_to_file(j)
+            return cu.write_str_to_file(j), updated
         else:
-            return self
+            return self, updated
 
     def deepcopy(self, uri_type=None, uri_exts=()):
         """Supported file extensions: .json, .tsv and .csv
         """
         fname_wo_ext, ext = os.path.splitext(self._uri)
 
-        if ext in uri_exts:
-            if ext == '.json':
-                return self.__deepcopy_json(uri_type, uri_exts)
-            elif ext == '.tsv':
-                return self.__deepcopy_tsv(uri_type, uri_exts, delim='\t')
-            elif ext == '.csv':
-                return self.__deepcopy_tsv(uri_type, uri_exts, delim=',')
-            else:
-                NotImplementedError('ext: {}.'.format(ext))
-        return self
+        if self._can_deepcopy:
+            if ext in uri_exts:
+                if ext == '.json':
+                    return self.__deepcopy_json(uri_type, uri_exts)
+                elif ext == '.tsv':
+                    return self.__deepcopy_tsv(uri_type, uri_exts, delim='\t')
+                elif ext == '.csv':
+                    return self.__deepcopy_tsv(uri_type, uri_exts, delim=',')
+                else:
+                    NotImplementedError('ext: {}.'.format(ext))
+
+            # copy if target URI type is different
+            if self._uri_type != uri_type:
+                return self.get_file(uri_type=uri_type), True
+
+        return self._uri, False
 
     def rm(self, quiet=False):
         """Remove file

--- a/caper/caper_uri.py
+++ b/caper/caper_uri.py
@@ -624,7 +624,7 @@ class CaperURI(object):
                 cu.set_uri_type_no_copy(uri_type)
             return cu.write_str_to_file(j), updated
         else:
-            return self, updated
+            return self._uri, updated
 
     def deepcopy(self, uri_type=None, uri_exts=()):
         """Supported file extensions: .json, .tsv and .csv

--- a/test/test_caper_uri.py
+++ b/test/test_caper_uri.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Tester for CaperURI
+
+Author:
+    Jin Lee (leepc12@gmail.com) at ENCODE-DCC
+"""
+
+import unittest
+import os
+import json
+
+try:
+    import caper
+except:
+    import sys, os
+    script_path = os.path.dirname(os.path.realpath(__file__))
+    sys.path.append(os.path.join(script_path, '../'))
+    import caper
+
+from caper import caper_uri
+from caper.caper_uri import CaperURI, URI_GCS, URI_LOCAL
+
+class TestCaperURI(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(TestCaperURI, self).__init__(*args, **kwargs)
+        caper_uri.init_caper_uri(
+            tmp_dir='~/.caper/test/tmp_dir',
+            tmp_s3_bucket='s3://encode-pipeline-test-runs/caper_tmp',
+            tmp_gcs_bucket='gs://encode-pipeline-test-runs/caper_tmp',
+            verbose=True)
+
+    def test_deepcopy(self):
+        tmp_json = {
+            # 'file1' : 'gs://encode-pipeline-genome-data/hg38_chr19_chrM_caper.tsv',
+            'file2' : 'string',
+            'file3' : 'gs://xxx',
+            'file3' : '~/.bashrc',
+            'file4' : 's3://encode-pipeline-genome-data/hg38_chr19_chrM_aws.tsv',
+        }
+        tmp_json_file = os.path.expanduser('~/.caper/test/tmp.json')
+        with open(tmp_json_file, 'w') as fp:
+            fp.write(json.dumps(tmp_json, indent=4))
+        f, _ = CaperURI(tmp_json_file).deepcopy(URI_GCS, uri_exts=('.tsv','.json'))
+        print(f)
+        # c.get_local_file()
+        # c = CaperURI('gs://encode-pipeline-genome-data/hg38_chr19_chrM_caper.tsv').deepcopy(URI_LOCAL, uri_exts=('.tsv'))
+        # c = CaperURI('https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM_caper.tsv').deepcopy(URI_GCS, uri_exts=('.tsv'))
+        # c = CaperURI('https://storage.googleapis.com/encode-pipeline-genome-data/hg38_chr19_chrM_caper.tsv').deepcopy(URI_GCS, uri_exts=('.tsv'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* Deprecated parameters
  - `--deepcopy`: Deepcopy is enable by default. `--no-deepcopy` is added to disable it.
  - `--use-docker`: `--docker` can work as a flag
  - `--use-singularity`: `--singularity` can work as a flag

* New parameters
  - `--no-deepcopy`: to disable deepcopy
  - `--dry-run`: Caper creates all temporary files but does not take any action.

* New subcommand
  - `debug`: an alias of `troubleshoot`, which is too long to type.

* Bug fixes
  - Fixed all deepcopy-related bugs