### PR TITLE
Dev11

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,208 +8,215 @@ Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and 
 
 ## Installation
 
-Make sure that you have `python3`(> 3.4.1) installed on your system. Use `pip` to install Caper.
-```bash
-$ pip install caper
-```
-
-Or `git clone` this repo and manually add `bin/` to your environment variable `PATH` in your BASH startup scripts (`~/.bashrc`).
-
-```bash
-$ git clone https://github.com/ENCODE-DCC/caper
-$ echo "export PATH=\"\$PATH:$PWD/caper/bin\"" >> ~/.bashrc
-```
-
-Test-run Caper. This will also auto-generate a default configuration file for Caper (`~/.caper/default.conf`).
-```
-$ caper
-```
-
-If you see an error message like `command unknown` then add the following line to the bottom of `~/.bashrc` and re-login.
-```
-export PATH=$PATH:~/.local/bin
-```
-
-## Configuration for Amazon Web Service (AWS)
-
-[Configure for AWS](docs/conf_aws.md) first. Create a small instance on AWS. SSH to it and Install Caper there. Edit/create `~/.caper/default.conf` like the following. Remove everything else from it. Define AWS Batch ARN `awd-batch-arn`, AWS region `aws-region` and an output bucket address `out-s3-bucket`. A file-based Cromwell database grows quickly to reach several GBs. Define `file-db` as a path on a mounted large file system.
-```
-[defaults]
-backend=aws
-#file-db=[PATH_FOR_CROMWELL_METADATA_DB]
-#tmp-dir=[TMP_DIR_FOR_INTER_STORAGE_FILE_TRANSFER]
-aws-batch-arn=[ARN_FOR_YOUR_AWS_BATCH]
-aws-region=[YOUR_AWS_REGION]
-out-s3-bucket=s3://[YOUR_OUTPUT_ROOT_BUCKET]/[ANY]/[WHERE]
-
-1) Caper run mode (for a single workflow)
-	```
-	$ caper submit [WDL] -i [INPUT_JSON]
+1) Make sure that you have Java (>= 1.8) installed on your system.
+	```bash
+	$ java -version
 	```
 
-2) Caper server/client mode (for multiple workflows)
-	Run a caper server. Use `screen`, `tmux` or `nohup` to keep this session alive.
-	```
-	$ caper server
-	```
-	Open another SSH session and submit a workflow to the server.
-	```
-	$ caper submit [WDL] -i [INPUT_JSON]
+2-1) Make sure that you have `python3`(> 3.4.1) installed on your system. Use `pip` to install Caper.
+	```bash
+	$ pip install caper
 	```
 
-## Configuration for Google Cloud Platform (GCP)
+2-2) Or `git clone` this repo and manually add `bin/` to your environment variable `PATH` in your BASH startup scripts (`~/.bashrc`).
 
-[Configure for gcloud and gsutil](docs/conf_gcp.md). Create a small instance on your project. SSH to it and Install Caper there. Edit/create `~/.caper/default.conf` like the following. Remove everything else from it. Define Google Cloud Platform Project `gcp-prj` and an output bucket address `out-gcs-bucket`.
-```
-[defaults]
-backend=gcp
-gcp-prj=[YOUR_GCP_PROJECT_NAME]
-out-gcs-bucket=gs://[YOUR_OUTPUT_ROOT_BUCKET]/[ANY]/[WHERE]
-```
+	```bash
+	$ git clone https://github.com/ENCODE-DCC/caper
+	$ echo "export PATH=\"\$PATH:$PWD/caper/bin\"" >> ~/.bashrc
+	```
 
-## Configuration for general computer
+3) Test-run Caper.
+	```bash
+	$ caper
+	```
 
-1) Edit `~/.caper/default.conf` like the following. Remove everything else from it.
-2) Define an output directory `out-dir`.
-```
-[defaults]
-backend=local
-out-dir=[YOUR_OUTPUT_DIRECTORY]
-```
+4) If you see an error message like `command unknown` then add the following line to the bottom of `~/.bashrc` and re-login.
+	```bash
+	export PATH=$PATH:~/.local/bin
+	```
 
-## Configuration for Stanford Sherlock
-1) Edit `~/.caper/default.conf` like the following. Remove everything else from it.
-2) Define an output directory `out-dir` and SLURM partition `slurm-partition`.
-```
-[defaults]
-backend=slurm
-slurm-partition=[SHERLOCK_SLURM_PARTITION]
-out-dir=[YOUR_OUTPUT_DIRECTORY]
-```
+5) Choose a platform from the following table and initialize Caper. This will create a default Caper configuration file `~/.caper/default.conf`. There are special platforms for Stanford Sherlock/SCG users.
+	```bash
+	$ caper init [PLATFORM]
+	```
 
-## Configuration for Stanford SCG
-1) Edit `~/.caper/default.conf` like the following. Remove everything else from it.
-2) Define an output directory `out-dir` and SLURM account `slurm-account`.
-```
-[defaults]
-backend=slurm
-slurm-account=[SCG_SLURM_ACCOUNT]
-out-dir=[YOUR_OUTPUT_DIRECTORY]
-```
+	**Platform**|**Description**
+	:--------|:-----
+	sherlock | Stanford Sherlock cluster (SLURM)
+	scg | Stanford SCG cluster (SLURM)
+	gcp | Google Cloud Platform
+	aws | Amazon Web Service
+	local | General local computer
+	sge | HPC with Sun GridEngine cluster engine
+	pbs | HPC with PBS cluster engine
+	slurm | HPC with SLURM cluster engine
 
-## Configuration for general SGE clusters
+6) Edit `~/.caper/default.conf` according to your chosen platform. Find instruction for each item in the following table.
+	> **IMPORTANT**: DEFINE ALL PARAMETERS IN THE CONFIGURATION FILE `~/.caper/default.conf` OR CAPER WILL NOT WORK CORRECTLY
 
-Edit `~/.caper/default.conf` like the following. Remove everything else from it. Define an output directory `out-dir`. Uncomment/define SGE queue settings according to your cluster's policy.
-```
-[defaults]
-backend=slurm
-sge-pe=[YOUR_PARALLEL_ENVIRONMENT]
-#sge-queue=[YOUR_SGE_QUEUE]
-out-dir=[YOUR_OUTPUT_DIRECTORY]
+	**Parameter**|**Description**
+	:--------|:-----
+	tmp-dir | **IMPORTANT**: A directory to store all cached files for inter-storage file transfer. DO NOT USE `/tmp`.
+	slurm-partition | SLURM partition. Define only if required by a cluster. You must define it for Stanford Sherlock.
+	slurm-account | SLURM partition. Define only if required by a cluster. You must define it for Stanford SCG.
+	sge-pe | Parallel environment of SGE. Find one with `$ qconf -spl` or ask you admin to add one if not exists.
+	aws-batch-arn | ARN for AWS Batch.
+	aws-region | AWS region (e.g. us-west-1)
+	out-s3-bucket | Output bucket path for AWS. This should start with `s3://`.
+	gcp-prj | Google Cloud Platform Project
+	out-gcs-bucket | Output bucket path for Google Cloud Platform. This should start with `gs://`.
+	file-db | Path for file DB to use Cromwell's call-caching (re-using previous workflow's output).
 
-port=8010
-```
+7-1) To use Caper on Google Cloud Platform (GCP), [configure for GCP](docs/conf_gcp.md). 
+7-2) To use Caper on Amazon Web Service (AWS), [configure for AWS](docs/conf_aws.md).
 
-Run Caper. Make sure to keep your SSH session alive.
+## Output directory
 
-Deepcopy is activate by default and URIs (`http(s)://`, `s3://`, `gs://`, ...) in your input JSON will be recursively copied into a target storage for a corresponding chosen backend. For example, GCS bucket (`gs://`) for GCP backend (`gcp`).
+> **IMPORTANT**: Unless you are running Caper on cloud platforms (`aws`, `gcp`) and `--out-dir` is not explicitly defined, all outputs will be written to a current working directory where you run `caper run` or `caper server`.
+
+Therefore, change directory first and run Caper there.
 
 ```bash
-$ caper run [WDL] -i [INPUT_JSON]
+$ cd [OUTPUT_DIR]
 ```
 
-Or run a Cromwell server with Caper. Make sure to keep server's SSH session alive.
+## Activating Conda environment
 
+If you want to use your Conda environment for Caper, then activate your Conda environment right before running/submitting `caper run` or `caper server`.
+```bash
+$ conda activate [PIPELINE_CONDA_ENV] 
+$ caper run ...
+$ sbatch ... --wrap "caper run ..."
+```
+
+## Running pipelines on Stanford Sherlock
+
+Submit a Caper leader job (`caper run`) to SLURM. For a partition `-p [SLURM_PARTITON]`, make sure that you use the same SLURM partition (`slurm-partition` in `~/.caper/default.conf`) as defined in Caper's configuration file. `-J [JOB_NAME]` is to identify Caper's leader job for each workflow. Make a separate directory for each workflow output will be written to each directory.
+
+```bash
+$ # conda activate here if required
+$ cd [OUTPUT_DIR]  # make a separate directory for each workflow.
+$ sbatch -p [SLURM_PARTITON] -J [JOB_NAME] --export=ALL --mem 2G -t 4-0 --wrap "caper run [WDL] -i [INPUT_JSON]"
+```
+
+A Caper leader job will `sbatch` lots of sub-tasks to SLURM so `squeue` will be mixed up with a leader job and its children jobs. It will be more convenient to filter out children jobs.
+```
+$ squeue -u $USER | grep -v cromwell
+```
+
+
+## Running pipelines on Stanford SCG
+
+Submit a Caper leader job for `caper run` to SLURM. For a SLURM account `-A [SLURM_ACCOUNT]` (this can be different from your own account, talk to your PI or admin), make sure that you use the same SLURM account (`slurm-account` in `~/.caper/default.conf`) as defined in Caper's configuration file. `-J [JOB_NAME]` is to identify Caper's leader job for each workflow. Make a separate directory for each workflow output will be written to each directory.
+
+```bash
+$ # conda activate here if required
+$ cd [OUTPUT_DIR]  # make a separate directory for each workflow
+$ sbatch -A [SLURM_ACCOUNT] -J [JOB_NAME] --export=ALL --mem 2G -t 4-0 --wrap "caper run [WDL] -i [INPUT_JSON]"
+```
+
+A Caper leader job will `sbatch` lots of sub-tasks to SLURM so `squeue` will be mixed up with a leader job and its children jobs. It will be more convenient to filter out children jobs.
+```
+$ squeue -u $USER | grep -v cromwell
+```
+
+## Running pipelines on SLURM clusters
+
+Submit a Caper leader job for `caper run` to SLURM. Define or skip a SLURM account `-A [SLURM_ACCOUNT]` or a SLURM partition `-p [SLURM_PARTITON]` according to your SLURM's configuration. Make sure that those parameters match with whatever defined (`slurm-account` or `slurm-partition` in `~/.caper/default.conf`) in Caper's configuration file. `-J [JOB_NAME]` is to identify Caper's leader job for each workflow. Make a separate directory for each workflow output will be written to each directory.
+
+```bash
+$ # conda activate here if required
+$ cd [OUTPUT_DIR]  # make a separate directory for each workflow
+$ sbatch -A [SLURM_ACCOUNT] -p [SLURM_PARTITON] -J [JOB_NAME] --export=ALL --mem 2G -t 4-0 --wrap "caper run [WDL] -i [INPUT_JSON]"
+```
+
+A Caper leader job will `sbatch` lots of sub-tasks to SLURM so `squeue` will be mixed up with a leader job and its children jobs. It will be more convenient to filter out children jobs.
+```
+$ squeue -u $USER | grep -v cromwell
+```
+
+## Running pipelines on SGE clusters
+
+Submit a Caper leader job for `caper run` to SGE. `-N [JOB_NAME]` is to identify Caper's leader job for each workflow. Make a separate directory for each workflow output will be written to each directory.
+```bash
+$ # conda activate here if required
+$ cd [OUTPUT_DIR]  # make a separate directory for each workflow
+$ echo "caper run [WDL] -i [INPUT_JSON]" | qsub -V -N [JOB_NAME] -l h_rt=144:00:00 -l h_vmem=2G
+```
+
+A Caper leader job will `qsub` lots of sub-tasks to SGE so `qstat` will be mixed up with a leader job and its children jobs. It will be more convenient to filter out children jobs.
+```
+$ qstat | grep -v cromwell
+```
+
+## Running pipelines on cloud platforms (GCP and AWS)
+
+Create a small leader instance on your GCP project/AWS region. Follow above installation instruction to install `Java`, Caper and Docker.
+
+> **IMPORTANT**: It's **STRONGLY** recommended to attach/mount a persistent disk/EBS volume with enough space to it. Caper's call-caching file DB grows quickly to reach 10 GB, which is a default size for most small instances.
+
+Also, make sure that `tmp-dir` in `~/.caper/default.conf` points to a directory on a large disk. All intermediate files and big cached files for inter-storage transfer will be stored there.
+
+Mount a persistent disk and change directory into it. A **BIG** DB file to enable Cromwell's call-caching (re-using previous failed workflow's outputs) will be generated on this current working directory.
+```bash
+$ cd /mnt/[MOUNTED_DISK]/[OUTPUT_DIR]
+```
+
+Make a screen to keep the session alive. Use the same command line to reattach to it.
+```bash
+$ screen -RD caper_server
+```
+
+Run a server on a screen. Detach from the screen (`Ctrl+A` and then `d`).
 ```bash
 $ caper server
 ```
 
-Then submit a workflow to the server.
+Submit a workflow to the server. All pipeline outputs will be written to `out-gcs-bucket` (for GCP) or `out-s3-bucket` (for AWS) in defined `~/.caper/default.conf`.
 ```bash
 $ caper submit [WDL] -i [INPUT_JSON]
 ```
 
-On HPCs (e.g. Stanford Sherlock and SCG), you can run Caper with a Singularity container if that is [defined inside `WDL`](DETAILS.md/#wdl-customization). For example, ENCODE [ATAC-seq](https://github.com/ENCODE-DCC/atac-seq-pipeline/blob/master/atac.wdl#L5) and [ChIP-seq](https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/master/chip.wdl#L5) pipelines.
-```bash
-$ caper run [WDL] -i [INPUT_JSON] --singularity
+Monitor your workflows.
+```
+$ caper list
 ```
 
-Or specify your own Singularity container.
+## Running pipelines on general computers
+
+Make a separate directory for each workflow.
 ```bash
-$ caper run [WDL] -i [INPUT_JSON] --singularity [YOUR_OWN_SINGULARITY_IMAGE_URI]
+$ # conda activate here if required
+$ cd [OUTPUT_DIR]  # make a separate directory for each workflow
+$ caper run [WDL] -i [INPUT_JSON]
 ```
 
-Similarly for Docker.
+## File DB and resuming failed workflows
+
+Caper defaults to use a file DB, which will grow quickly to reach several GBs, to store metadata for outputs of previous workflows. This metadata DB is used for call-caching (re-using outputs from previous workflows) of Cromwell. You can disable it with `--no-file-db` or `-n` but it's strongly recommended to use one.
+
+This file DB is genereted on your working directory by default. Its default filename prefix is `caper_file_db.[INPUT_JSON_BASENAME_WO_EXT]`. A DB is consist of multiple files and directories with the same filename prefix.
+
+Unless you explicitly define `file-db` in your configuration file `~/.caper/default.conf` this file DB name will depend on your input JSON filename. Therefore, you can simply resume a failed workflow with the same command line used for starting a new pipeline.
+
+For example, assume that you have run your pipeline with the following command line. Then you will see a bunch of files/directories (`caper_file_db.input1*`) generated for a DB.
 ```bash
-$ caper run [WDL] -i [INPUT_JSON] --docker
+$ caper run /atac-seq-pipeline/atac.wdl -i input1.json
 ```
 
+Unfortunately your pipeline failed and you corrected your input JSON but didn't change its filename. Then simply re-run with the same command line to restart from where it left off.
 ```bash
-$ caper run [WDL] -i [INPUT_JSON] --docker [YOUR_OWN_DOCKER_IMAGE_URI]
+$ caper run /atac-seq-pipeline/atac.wdl -i input1.json
 ```
 
-## HPCs
-
-> **Run mode on HPCs**: We don't recommend to run Caper on a login node. Caper/Cromwell will be killed while building a local Singularity image or deepcopying remote files. Also Cromwell is a Java application which is not lightweight.
-
-Install Java and Singularity locally or load cluster's Java module.
+However, if you have changed input JSON filename then explicitly define previous failed workflow's file DB prefix with `--file-db` or `-d`.
 ```bash
-$ module load java
-$ module load singularity
+$ caper run /atac-seq-pipeline/atac.wdl -i input1.json --file-db caper_file_db.input1
 ```
 
-You are not submitting workflows to your cluster engine (e.g. SLURM). You are submitting Caper to the engine and Caper will work as another job manager which `will `sbatch` and `qsub` subtasks defined in WDL. So don't give Caper too much resource. one CPU, 1GB RAM and long enough walltime will be enough.
+You can also define `file-db` in your configuration file `~/.caper/default.conf` and use it for all workflows. But please note that you can only run a single workflow at the same time with `caper run` since this will take a sole control on this DB file.
 
-For Caper run mode, you cannot `caper run` multiple workflows with a single `--file-db` because they will try to write on the same DB file. Give each workflow a different `--file-db`. `--file-db` is important when you want to resume your failed workflows and automatically re-use outputs from previous workflows.
-
-1) SLURM: 1 cpu, 2GB of RAM and 7 days of walltime. You may need to define a partition of an account according to your cluster's SLURM configuration. Then define them for `sbatch` (not for `caper`).
-
-	```bash
-	$ sbatch --export=ALL -n 1 --mem 2G -t 7-0 --wrap "caper run [WDL] -i [INPUT_JSON]"
-	```
-
-2) SGE: 1 cpu, 2GB of RAM and 7 days of walltime.
-
-	```bash
-	$ echo "caper run [WDL] -i [INPUT_JSON]" | qsub -l h_rt=144:00:00 -l h_vmem=2G
-	```
-
-> **Server/client mode on HPCs**: We recommend to run a server on a non-login node with at least one CPU, 2GB RAM and long enough walltime. Take IP address of your compute node and update your default configuration file with it. If there is any conflicting port, then change port in your configuration file. If default port 8000 is already taken the try with another port.
-
-For Caper server mode, you can submit multiple workflows with a single `--file-db`.
-
-1) SLURM: 1 cpu, 12GB of RAM and 7 days of walltime. You may need to define a partition `-p` of an account `--account` according to your cluster's SLURM configuration. Then define them for `sbatch` (not for `caper`).
-
-	```bash
-	$ sbatch --export=ALL -n 1 --mem 10G -t 7-0 --wrap "caper server"
-
-	# get hostname of Cromwell server 
-	$ squeue -u $USER
-	```
-
-	For example on Stanford Sherlock. Hostname is `sh-102-32` for this example.
-	```bash
-	[leepc12@sh-ln07 login ~]$ sbatch --export=ALL -n 1 --mem 10G -t 7-0 -p akundaje -o ~/caper_server.o -e ~/caper_server.e --wrap "caper server"
-	Submitted batch job 44439486
-
-	[leepc12@sh-ln07 login ~]$ squeue -u $USER
-             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
-          44439486  akundaje     wrap  leepc12  R       2:34      1 sh-102-32
-	```
-
-2) SGE: 1 cpu, 2GB of RAM and 7 days of walltime.
-
-	```bash
-	$ echo "caper server --port 8000 [YOUR_CAPER_SERVER_EXTRA_PARAMS] --file-db [YOUR_FILE_DB]" | qsub -l h_rt=144:00:00 -l h_vmem=10G
-
-	# get hostname of Cromwell server 
-	$ qstat
-	```
-
-Submit workflows to the server.
-```bash
-$ caper submit [WDL] -i [INPUT_JSPN] --ip [SERVER_HOSTNAME]
-```
+You can also use an external MySQL database to avoid only-one-DB-connection issue. See details section for it.
 
 # DETAILS
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and 
 	export PATH=$PATH:~/.local/bin
 	```
 
-5) Choose a platform from the following table and initialize Caper. This will create a default Caper configuration file `~/.caper/default.conf`. There are special platforms for Stanford Sherlock/SCG users.
+5) Choose a platform from the following table and initialize Caper. This will create a default Caper configuration file `~/.caper/default.conf`, which have only required parameters for each platform. There are special platforms for Stanford Sherlock/SCG users.
 	```bash
 	$ caper init [PLATFORM]
 	```
@@ -56,7 +56,7 @@ Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and 
 	slurm | HPC with SLURM cluster engine
 
 6) Edit `~/.caper/default.conf` according to your chosen platform. Find instruction for each item in the following table.
-	> **IMPORTANT**: DEFINE ALL PARAMETERS IN THE CONFIGURATION FILE `~/.caper/default.conf` OR CAPER WILL NOT WORK CORRECTLY
+	> **IMPORTANT**: ONCE YOU HAVE INITIALIZED THE CONFIGURATION FILE `~/.caper/default.conf` WITH YOUR CHOSEN PLATFORM, THEN IT WILL HAVE ONLY REQUIRED PARAMETERS FOR THE CHOSEN PLATFORM. DO NOT LEAVE ANY PARAMETERS UNDEFINED OR CAPER WILL NOT WORK CORRECTLY.
 
 	**Parameter**|**Description**
 	:--------|:-----
@@ -71,8 +71,7 @@ Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and 
 	out-gcs-bucket | Output bucket path for Google Cloud Platform. This should start with `gs://`.
 	file-db | Path for file DB to use Cromwell's call-caching (re-using previous workflow's output).
 
-7-1) To use Caper on Google Cloud Platform (GCP), [configure for GCP](docs/conf_gcp.md). 
-7-2) To use Caper on Amazon Web Service (AWS), [configure for AWS](docs/conf_aws.md).
+7) To use Caper on Google Cloud Platform (GCP), [configure for GCP](docs/conf_gcp.md). To use Caper on Amazon Web Service (AWS), [configure for AWS](docs/conf_aws.md).
 
 ## Output directory
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,18 @@ Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and 
 ## Installation
 
 1) Make sure that you have Java (>= 1.8) installed on your system.
+
 	```bash
 	$ java -version
 	```
 
-2-1) Make sure that you have `python3`(> 3.4.1) installed on your system. Use `pip` to install Caper.
+2) Make sure that you have `python3`(> 3.4.1) installed on your system. Use `pip` to install Caper.
+
 	```bash
 	$ pip install caper
 	```
 
-2-2) Or `git clone` this repo and manually add `bin/` to your environment variable `PATH` in your BASH startup scripts (`~/.bashrc`).
+	If `pip` doesn't work then `git clone` this repo and manually add `bin/` to your environment variable `PATH` in your BASH startup scripts (`~/.bashrc`).
 
 	```bash
 	$ git clone https://github.com/ENCODE-DCC/caper
@@ -26,11 +28,13 @@ Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and 
 	```
 
 3) Test-run Caper.
+
 	```bash
 	$ caper
 	```
 
-4) If you see an error message like `command unknown` then add the following line to the bottom of `~/.bashrc` and re-login.
+4) If you see an error message like `caper: command not found` then add the following line to the bottom of `~/.bashrc` and re-login.
+
 	```bash
 	export PATH=$PATH:~/.local/bin
 	```

--- a/README.md
+++ b/README.md
@@ -20,251 +20,95 @@ $ git clone https://github.com/ENCODE-DCC/caper
 $ echo "export PATH=\"\$PATH:$PWD/caper/bin\"" >> ~/.bashrc
 ```
 
-## Usage
-
-There are 7 subcommands available for Caper. Except for `run` other subcommands work with a running Caper server, which can be started with `server` subcommand. `server` does not require a positional argument. `WF_ID` (workflow ID) is a UUID generated from Cromwell to identify a workflow. `STR_LABEL` is Caper's special string label to be used to identify a workflow.
-
-**Subcommand**|**Positional args** | **Description**
-:--------|:-----|:-----
-server   |      |Run a Cromwell server with built-in backends
-run      | WDL  |Run a single workflow (not recommened for multiple workflows)
-submit   | WDL  |Submit a workflow to a Cromwell server
-abort    | WF_ID or STR_LABEL |Abort submitted workflows on a Cromwell server
-unhold   | WF_ID or STR_LABEL |Release hold of workflows on a Cromwell server
-list     | WF_ID or STR_LABEL |List submitted workflows on a Cromwell server
-metadata | WF_ID or STR_LABEL |Retrieve metadata JSONs for workflows
-troubleshoot | WF_ID, STR_LABEL or<br>METADATA_JSON_FILE |Analyze reason for errors
-
-* `run`: To run a single workflow. A string label `-s` is optional and useful for other subcommands to indentify a workflow.
-
-	```bash
-	$ caper run [WDL] -i [INPUT_JSON]
-	```
-
-	> **WARNING**: If you try to run multiple workflows at the same time then you will see a `db - Connection is not available` error message since multiple Caper instances will try to lock the same DB file `~/.caper/default_file_db`.
-
-	```bash
-	java.sql.SQLTransientConnectionException: db - Connection is not available, request timed out after 3000ms.
-	```
-
-	> **WORKAROUND**: Define a different DB file per run with `--file-db`. Or start a caper server and submit multiple workflows to it so that the DB file is taken by one caper server only. Or use a server-based [MySQL database](DETAILS.md/#mysql-server) instead or disable connection to DB with `--no-file-db` or `-n` but you will not be able to use [Cromwell's call-caching](https://cromwell.readthedocs.io/en/develop/Configuring/#call-caching) to re-use outputs from previous workflows.
-
-* `server`: To start a server. You can define a server port with `--port`. Use a different port for each server for multiple servers. If you don't use a default port (`8000`). Then define `--port` for all client subcommands like `submit`, `list` and `troubleshoot`. If you run a server on a different IP address or hostname, then define it with `--ip` for all client subcomands like `submit`.
-
-	```bash
-	$ caper server
-	```
-
-* `submit`: To submit a workflow to a server. Define a string label for submitted workflow with `-s`. It is optional but useful for other subcommands to indentify a workflow.
-
-	```bash
-	$ caper submit [WDL] -i [INPUT_JSON] -s [STR_LABEL] 
-	```
-
-* `list`: To show a list of all workflows submitted to a cromwell server. Wildcard search with using `*` and `?` is allowed for such label for the following subcommands with `STR_LABEL`. 
-
-	```bash
-	$ caper list [WF_ID or STR_LABEL]
-	```
-
-* `troubleshoot`: To analyze reasons for workflow failures. You can specify failed workflow's metadata JSON file or workflow IDs and labels. Wildcard search with using `*` and `?` is allowed for string labels.
-
-	```bash
-	$ caper troubleshoot [WF_ID, STR_LABEL or METADATA_JSON_FILE]
-	```
-
-* Other subcommands: Other subcommands work similar to `list`. It does a corresponding action for matched workflows.
-
-
-## Configuration file
-
-Run Caper without parameters to generate a default configuration file.
-```bash
+Test-run Caper. This will also auto-generate a default configuration file for Caper (`~/.caper/default.conf`).
+```
 $ caper
 ```
 
-Caper automatically creates a default configuration file at `~/.caper/default.conf`. Such configruation file comes with all available parameters commented out. You can uncomment/define any parameter to activate it.
-
-You can avoid repeatedly defining same parameters in your command line arguments. For example, you can define `out-dir` and `tmp-dir` in your configuration file instead of defining them in command line arguments.
+If you see an error message like `command unknown` then add the following line to the bottom of `~/.bashrc` and re-login.
 ```
-$ caper run [WDL] --out-dir [LOCAL_OUT_DIR] --tmp-dir [LOCAL_TMP_DIR]
+export PATH=$PATH:~/.local/bin
 ```
 
-Equivalent settings in a configuration file.
-```
-[defaults]
+## Configuration for Amazon Web Service (AWS)
 
-out-dir=[LOCAL_OUT_DIR]
-tmp-dir=[LOCAL_TMP_DIR]
-```
-
-## Minimum required parameters
-
-An auto-generated default configuration has a `Minimum required parameters` section on top. Other parameters in other sections are optional and most users will not be interested in them. If you don't see this section then remove existing default configuration file and regenerate it.
-
-Edit your configuration file (`~/.caper/default.conf` by default) and uncomment/define parameters for your preferred backend.
+[Configure for AWS](docs/conf_aws.md) first. Create a small instance on AWS. SSH to it and Install Caper there. Edit/create `~/.caper/default.conf` like the following. Remove everything else from it. Define AWS Batch ARN `awd-batch-arn`, AWS region `aws-region` and an output bucket address `out-s3-bucket`. A file-based Cromwell database grows quickly to reach several GBs. Define `file-db` as a path on a mounted large file system.
 ```
 [defaults]
+backend=aws
+#file-db=[PATH_FOR_CROMWELL_METADATA_DB]
+#tmp-dir=[TMP_DIR_FOR_INTER_STORAGE_FILE_TRANSFER]
+aws-batch-arn=[ARN_FOR_YOUR_AWS_BATCH]
+aws-region=[YOUR_AWS_REGION]
+out-s3-bucket=s3://[YOUR_OUTPUT_ROOT_BUCKET]/[ANY]/[WHERE]
 
-############ Minimum required parameters
-## Please read through carefully
+1) Caper run mode (for a single workflow)
+	```
+	$ caper submit [WDL] -i [INPUT_JSON]
+	```
 
-## Define file DB to use Cromwell's call-caching
-## Call-caching is important for restarting failed workflows
-## File DB can only be accessed by one caper process (caper run or server)
-## i.e. you cannot run multiple caper run with one file DB
-## For such case, we recommend to use caper server and submit multiple workflows to it
-## You can disable file DB with '--no-file-db' or '-n'
-#file-db=~/.caper/default_file_db
+2) Caper server/client mode (for multiple workflows)
+	Run a caper server. Use `screen`, `tmux` or `nohup` to keep this session alive.
+	```
+	$ caper server
+	```
+	Open another SSH session and submit a workflow to the server.
+	```
+	$ caper submit [WDL] -i [INPUT_JSON]
+	```
 
-## Define to use 'caper server' and all client subcommands like 'caper submit'
-## This is not required for 'caper run'
-#port=8000
+## Configuration for Google Cloud Platform (GCP)
 
-## Define default backend (local, gcp, aws, slurm, sge, pbs)
-#backend=local
-
-## Define output directory if you want to run pipelines locally
-#out-dir=
-
-## Define if you want to run pipelines on Google Cloud Platform
-#gcp-prj=encode-dcc-1016
-#out-gcs-bucket=gs://encode-pipeline-test-runs/project1/caper_out
-
-## Define if you want to run pipelines on AWS
-#aws-batch-arn=arn:....
-#aws-region=us-west-1
-#out-s3-bucket=s3://encode-pipeline-test-runs/project1/caper_out
-
-## Define if you want to run pipelines on SLURM
-## Define partition or account or both according to your cluster's requirements
-## For example, Stanford requires a partition and SCG requires an account.
-#slurm-partition=akundaje
-#slurm-account=akundaje
-
-## Define if you want to run pipelines on SGE
-#sge-pe=shm
-
-## Define if your SGE cluster requires a queue
-#sge-queue=q
-
-## Define if your PBS cluster requires a queue
-#pbs-queue=q
-```
-
-> **RECOMMENDATION**: Instead of using a default configuration file at `~/.caper/default.conf`, you can specify your own configuration file with `caper -c`. This is useful when you want to manage a configuration file per project (e.g. use a different file DB `--file-db` per project to prevent locking).
-```
-$ caper -c [YOUR_CONF_FILE_FOR_PROJECT_1] ...
-```
-
-## Running workflows on GCP/AWS backends
-
-Cloud backends (AWS and GCP) write outputs on corresponding storage buckets (s3 and gcs). Caper internally uses cloud CLIs `gsutil` and `aws`. Therefore, make sure that these CLIs are installed and configured correctly.
-
-> **WARNING**: On GCP backend you can deploy a workflow from your local computer. However due to AWS security reasons, you cannot do it on AWS backend. You need to spin up a AWS instance on AWS Console and configure for `aws` on the instance and run Caper there.
-
-1) Google Cloud Platform (GCP): Install [gsutil](https://cloud.google.com/storage/docs/gsutil_install). [Configure for gcloud and gsutil](docs/conf_gcp.md).
-
-2) AWS: [Configure for AWS](docs/conf_aws.md) first.
-
-## Deepcopy (auto inter-storage transfer)
-
-> **IMPORTANT**: `--deepcopy` has been deprecated and it's activated by default. You can disable it with `--no-deepcopy`.
-
-Deepcopy allows Caper to **RECURSIVELY** copy files defined in your input JSON into your target backend's temporary storage. For example, Cromwell cannot read directly from URLs in an [input JSON file](https://github.com/ENCODE-DCC/atac-seq-pipeline/blob/master/examples/caper/ENCSR356KRQ_subsampled.json), but Caper makes copies of these URLs on your backend's temporary directory (e.g. `--tmp-dir` for `local`, `--tmp-gcs-bucket` for `gcp`) and pass them to Cromwell.
-
-## How to manage configuration file per project
-
-It is useful to have a configuration file per project. For example of two projects.
-
-We want to run pipelines locally for project-1, run a server with `caper -c project_1.conf server` and submit a workflow with `caper -c project_1.conf submit [WDL] ...` or run a single workflow `caper -c project_1.conf run [WDL] ...`.
+[Configure for gcloud and gsutil](docs/conf_gcp.md). Create a small instance on your project. SSH to it and Install Caper there. Edit/create `~/.caper/default.conf` like the following. Remove everything else from it. Define Google Cloud Platform Project `gcp-prj` and an output bucket address `out-gcs-bucket`.
 ```
 [defaults]
-file-db=~/.caper/file_db_project_1
-port=8000
-backend=local
-out-dir=/scratch/user/caper_out_project_1
-```
-
-We want to run pipelines on Google Cloud Platform for project-2. Run a server with `caper -c project_2.conf server` and submit a workflow with `caper -c project_2.conf submit [WDL] ...` or run a single workflow `caper -c project_2.conf run [WDL] ...`.
-```
-[defaults]
-file-db=~/.caper/file_db_project_2
-port=8001
 backend=gcp
-gcp-prj=YOUR_GCP_PRJ_NAME
-out-gcs-bucket=gs://caper_out_project_2
+gcp-prj=[YOUR_GCP_PROJECT_NAME]
+out-gcs-bucket=gs://[YOUR_OUTPUT_ROOT_BUCKET]/[ANY]/[WHERE]
 ```
 
-Then you will see no conflict in file DBs and network ports (`8000` vs. `8001`) between two projects.
+## Configuration for general computer
 
+1) Edit `~/.caper/default.conf` like the following. Remove everything else from it.
+2) Define an output directory `out-dir`.
+```
+[defaults]
+backend=local
+out-dir=[YOUR_OUTPUT_DIRECTORY]
+```
 
-## How to run it
+## Configuration for Stanford Sherlock
+1) Edit `~/.caper/default.conf` like the following. Remove everything else from it.
+2) Define an output directory `out-dir` and SLURM partition `slurm-partition`.
+```
+[defaults]
+backend=slurm
+slurm-partition=[SHERLOCK_SLURM_PARTITION]
+out-dir=[YOUR_OUTPUT_DIRECTORY]
+```
 
-According to your chosen backend, define the following parameters in your default configuration file (`~/.caper/default.conf`).
+## Configuration for Stanford SCG
+1) Edit `~/.caper/default.conf` like the following. Remove everything else from it.
+2) Define an output directory `out-dir` and SLURM account `slurm-account`.
+```
+[defaults]
+backend=slurm
+slurm-account=[SCG_SLURM_ACCOUNT]
+out-dir=[YOUR_OUTPUT_DIRECTORY]
+```
 
-* Local
-	```
-	backend=local
-	out-dir=[LOCAL_OUT_DIR]
+## Configuration for general SGE clusters
 
-	# server mode
-	# ip is an IP address or hostname of a Cromwell server
-	# it's localhost by default but if you are submitting to
-	# a remote Cromwell server (e.g. from login node to a compute node)
-	# then take IP address of the server and write it here
-	ip=localhost
+Edit `~/.caper/default.conf` like the following. Remove everything else from it. Define an output directory `out-dir`. Uncomment/define SGE queue settings according to your cluster's policy.
+```
+[defaults]
+backend=slurm
+sge-pe=[YOUR_PARALLEL_ENVIRONMENT]
+#sge-queue=[YOUR_SGE_QUEUE]
+out-dir=[YOUR_OUTPUT_DIRECTORY]
 
-	# port is 8000 by default. but if it's already taken 
-	# then try other ports like 8001
-	port=8000
-	```
-
-* Google Cloud Platform (GCP): Install [gsutil](https://cloud.google.com/storage/docs/gsutil_install). [Configure for gcloud and gsutil](docs/conf_gcp.md).
-	```
-	backend=gcp
-	gcp-prj=YOUR_PRJ_NAME
-	out-gcs-bucket=gs://YOUR_OUTPUT_ROOT_BUCKET/ANY/WHERE
-	```
-
-* AWS: [Configure for AWS](docs/conf_aws.md) first.
-	```
-	backend=aws
-	aws-batch-arn=ARN_FOR_YOUR_AWS_BATCH
-	aws-region=YOUR_AWS_REGION
-	out-s3-bucket=s3://YOUR_OUTPUT_ROOT_BUCKET/ANY/WHERE
-	```
-
-* SLURM
-	```
-	backend=slurm
-	out-dir=[LOCAL_OUT_DIR]
-
-	# SLURM partition if required (e.g. on Stanford Sherlock)
-	slurm-partition=[YOUR_PARTITION]
-
-	# SLURM account if required (e.g. on Stanford SCG4)
-	slurm-account=[YOUR_ACCOUMT]
-
-	ip=localhost
-	port=8000
-	```
-
-* SGE
-
-	```
-	backend=sge
-	out-dir=[LOCAL_OUT_DIR]
-
-	# SGE PE (if you don't have it, ask your admin to create one)
-	sge-pe=[YOUR_PARALLEL_ENVIRONMENT]
-
-	# SGE queue if required
-	sge-queue=[YOUR_SGE_QUEUE]
-
-	ip=localhost
-	port=8000
-	```
+port=8010
+```
 
 Run Caper. Make sure to keep your SSH session alive.
 
@@ -277,13 +121,12 @@ $ caper run [WDL] -i [INPUT_JSON]
 Or run a Cromwell server with Caper. Make sure to keep server's SSH session alive.
 
 ```bash
-$ hostname  # get IP address or hostname of a compute/login node
 $ caper server
 ```
 
-Then submit a workflow to the server. A TCP port `--port` are optional if you have changed the default port `8000`. Server IP address `--ip` is optional for a local server.
+Then submit a workflow to the server.
 ```bash
-$ caper submit [WDL] -i [INPUT_JSON] --ip [SERVER_HOSTNAME] --port [PORT]
+$ caper submit [WDL] -i [INPUT_JSON]
 ```
 
 On HPCs (e.g. Stanford Sherlock and SCG), you can run Caper with a Singularity container if that is [defined inside `WDL`](DETAILS.md/#wdl-customization). For example, ENCODE [ATAC-seq](https://github.com/ENCODE-DCC/atac-seq-pipeline/blob/master/atac.wdl#L5) and [ChIP-seq](https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/master/chip.wdl#L5) pipelines.
@@ -309,35 +152,36 @@ $ caper run [WDL] -i [INPUT_JSON] --docker [YOUR_OWN_DOCKER_IMAGE_URI]
 
 > **Run mode on HPCs**: We don't recommend to run Caper on a login node. Caper/Cromwell will be killed while building a local Singularity image or deepcopying remote files. Also Cromwell is a Java application which is not lightweight.
 
-Install Java locally or load cluster's Java module.
+Install Java and Singularity locally or load cluster's Java module.
 ```bash
 $ module load java
+$ module load singularity
 ```
 
 You are not submitting workflows to your cluster engine (e.g. SLURM). You are submitting Caper to the engine and Caper will work as another job manager which `will `sbatch` and `qsub` subtasks defined in WDL. So don't give Caper too much resource. one CPU, 1GB RAM and long enough walltime will be enough.
 
 For Caper run mode, you cannot `caper run` multiple workflows with a single `--file-db` because they will try to write on the same DB file. Give each workflow a different `--file-db`. `--file-db` is important when you want to resume your failed workflows and automatically re-use outputs from previous workflows.
 
-1) SLURM: 1 cpu, 2GB of RAM and 7 days of walltime. `--partition` (e.g. Stanford Sherlock) and `--account` (e.g. Stanford SCG) are optional and depend on your cluster's SLURM configuration.
+1) SLURM: 1 cpu, 2GB of RAM and 7 days of walltime. You may need to define a partition of an account according to your cluster's SLURM configuration. Then define them for `sbatch` (not for `caper`).
 
 	```bash
-	$ sbatch --export=ALL -n 1 --mem 2G -t 7-0 --partition [YOUR_SLURM_PARTITON] --account [YOUR_SLURM_ACCOUNT] --wrap "caper run [WDL] -i [INPUT_JSON] [YOUR_CAPER_RUN_EXTRA_PARAMS] --file-db [YOUR_FILE_DB]"
+	$ sbatch --export=ALL -n 1 --mem 2G -t 7-0 --wrap "caper run [WDL] -i [INPUT_JSON]"
 	```
 
 2) SGE: 1 cpu, 2GB of RAM and 7 days of walltime.
 
 	```bash
-	$ echo "caper run [WDL] -i [INPUT_JSON] [YOUR_CAPER_RUN_EXTRA_PARAMS] --file-db [YOUR_FILE_DB]" | qsub -l h_rt=144:00:00 -l h_vmem=2G
+	$ echo "caper run [WDL] -i [INPUT_JSON]" | qsub -l h_rt=144:00:00 -l h_vmem=2G
 	```
 
 > **Server/client mode on HPCs**: We recommend to run a server on a non-login node with at least one CPU, 2GB RAM and long enough walltime. Take IP address of your compute node and update your default configuration file with it. If there is any conflicting port, then change port in your configuration file. If default port 8000 is already taken the try with another port.
 
 For Caper server mode, you can submit multiple workflows with a single `--file-db`.
 
-1) SLURM: 1 cpu, 12GB of RAM and 7 days of walltime. `--partition` (e.g. Stanford Sherlock) and `--account` (e.g. Stanford SCG) are optional and depend on your cluster's SLURM configuration.
+1) SLURM: 1 cpu, 12GB of RAM and 7 days of walltime. You may need to define a partition `-p` of an account `--account` according to your cluster's SLURM configuration. Then define them for `sbatch` (not for `caper`).
 
 	```bash
-	$ sbatch --export=ALL -n 1 --mem 10G -t 7-0 --partition [YOUR_SLURM_PARTITON] --account [YOUR_SLURM_ACCOUNT] --wrap "caper server --port 8000 [YOUR_CAPER_SERVER_EXTRA_PARAMS]"
+	$ sbatch --export=ALL -n 1 --mem 10G -t 7-0 --wrap "caper server"
 
 	# get hostname of Cromwell server 
 	$ squeue -u $USER
@@ -345,7 +189,7 @@ For Caper server mode, you can submit multiple workflows with a single `--file-d
 
 	For example on Stanford Sherlock. Hostname is `sh-102-32` for this example.
 	```bash
-	[leepc12@sh-ln07 login ~]$ sbatch --export=ALL -n 1 --mem 10G -t 7-0 -p akundaje -o ~/caper_server.o -e ~/caper_server.e --wrap "caper server --port 8000"
+	[leepc12@sh-ln07 login ~]$ sbatch --export=ALL -n 1 --mem 10G -t 7-0 -p akundaje -o ~/caper_server.o -e ~/caper_server.e --wrap "caper server"
 	Submitted batch job 44439486
 
 	[leepc12@sh-ln07 login ~]$ squeue -u $USER
@@ -364,9 +208,8 @@ For Caper server mode, you can submit multiple workflows with a single `--file-d
 
 Submit workflows to the server.
 ```bash
-$ caper submit [WDL] -i [INPUT_JSPN] -s [ANY_LABEL_FOR_WORKFLOW] --ip [SERVER_HOSTNAME] --port 8000
+$ caper submit [WDL] -i [INPUT_JSPN] --ip [SERVER_HOSTNAME]
 ```
-
 
 # DETAILS
 

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -1022,15 +1022,14 @@ class Caper(object):
                     job_id = call['jobId'] if 'jobId' in call else None
                     stdout = call['stdout'] if 'stdout' in call else None
                     stderr = call['stderr'] if 'stderr' in call else None
+                    run_start = None
+                    run_end = None
                     if 'executionEvents' in call:
                         for ev in call['executionEvents']:
                             if ev['description'].startswith('Running'):
                                 run_start = ev['startTime']
                                 run_end = ev['endTime']
                                 break
-                    else:
-                        run_start = None
-                        run_end = None
 
                     if not show_completed_task and \
                             task_status in ('Done', 'Succeeded'):

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -641,6 +641,12 @@ def parse_caper_arguments():
             args_d['tmp_gcs_bucket'] = os.path.join(args_d['out_gcs_bucket'],
                                                     '.caper_tmp')
     backend = args_d.get('backend')
+    if backend is not None:
+        if backend == 'google':
+            backend = 'gcp'
+        elif backend == 'amazon':
+            backend = 'aws'
+        args_d['backend'] = backend
 
     file_db = args_d.get('file_db')
     if file_db is not None:

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -567,30 +567,30 @@ def parse_caper_arguments():
     # convert to dict
     args_d = vars(args)
 
-    dry_run = args_d.get('dry_run')
-    if dry_run is not None and isinstance(dry_run, str):
-        args_d['dry_run'] = bool(strtobool(dry_run))
+    # string to boolean
+    for k in [
+        'dry_run',
+        'disable_call_caching',
+        'use_gsutil_over_aws_s3',
+        'hold',
+        'no_deepcopy',
+        'no_build_singularity',
+        'no_file_db',
+        'use_netrc',
+        'show_completed_task']:
+        v = args_d.get(k)
+        if v is not None and isinstance(v, str):
+            args_d[k] = bool(strtobool(v))
 
-    # boolean string to boolean
-    disable_call_caching = args_d.get('disable_call_caching')
-    if disable_call_caching is not None \
-            and isinstance(disable_call_caching, str):
-        args_d['disable_call_caching'] = \
-            bool(strtobool(disable_call_caching))
-
-    use_gsutil_over_aws_s3 = args_d.get('use_gsutil_over_aws_s3')
-    if use_gsutil_over_aws_s3 is not None \
-            and isinstance(use_gsutil_over_aws_s3, str):
-        args_d['use_gsutil_over_aws_s3'] = \
-            bool(strtobool(use_gsutil_over_aws_s3))
-
-    hold = args_d.get('hold')
-    if hold is not None and isinstance(hold, str):
-        args_d['hold'] = bool(strtobool(hold))
-
-    no_deepcopy = args_d.get('no_deepcopy')
-    if no_deepcopy is not None and isinstance(no_deepcopy, str):
-        args_d['no_deepcopy'] = bool(strtobool(no_deepcopy))
+    # string to int
+    for k in [
+        'db_timeout',
+        'max_retries',
+        'max_concurrent_tasks',
+        'max_concurrent_workflows']:
+        v = args_d.get(k)
+        if v is not None and isinstance(v, str):
+            args_d[k] = int(v)
 
     docker = args_d.get('docker')
     if docker is not None:
@@ -624,45 +624,6 @@ def parse_caper_arguments():
 
     if use_docker and use_singularity:
         raise Exception('--docker and --singularity are mutually exclusive')
-
-    no_build_singularity = args_d.get('no_build_singularity')
-    if no_build_singularity is not None \
-            and isinstance(no_build_singularity, str):
-        args_d['no_build_singularity'] = bool(strtobool(no_build_singularity))
-
-    no_file_db = args_d.get('no_file_db')
-    if no_file_db is not None and isinstance(no_file_db, str):
-        args_d['no_file_db'] = bool(strtobool(no_file_db))
-
-    use_netrc = args_d.get('use_netrc')
-    if use_netrc is not None and isinstance(use_netrc, str):
-        args_d['use_netrc'] = bool(strtobool(use_netrc))
-
-    show_completed_task = args_d.get('show_completed_task')
-    if show_completed_task is not None and \
-            isinstance(show_completed_task, str):
-        args_d['show_completed_task'] = bool(strtobool(show_completed_task))
-
-    # int string to int
-    max_concurrent_tasks = args_d.get('max_concurrent_tasks')
-    if max_concurrent_tasks is not None \
-            and isinstance(max_concurrent_tasks, str):
-        args_d['max_concurrent_tasks'] = int(max_concurrent_tasks)
-
-    max_concurrent_workflows = args_d.get('max_concurrent_workflows')
-    if max_concurrent_workflows is not None \
-            and isinstance(max_concurrent_workflows, str):
-        args_d['max_concurrent_workflows'] = int(max_concurrent_workflows)
-
-    db_timeout = args_d.get('db_timeout')
-    if db_timeout is not None \
-            and isinstance(db_timeout, str):
-        args_d['db_timeout'] = int(db_timeout)
-
-    max_retries = args_d.get('max_retries')
-    if max_retries is not None \
-            and isinstance(max_retries, str):
-        args_d['max_retries'] = int(max_retries)
 
     # init some important path variables
     if args_d.get('out_dir') is None:

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -17,7 +17,7 @@ __version__ = '0.4.0'
 DEFAULT_JAVA_HEAP_SERVER = '7G'
 DEFAULT_JAVA_HEAP_RUN = '1G'
 DEFAULT_CAPER_CONF = '~/.caper/default.conf'
-DEFAULT_FILE_DB = '~/.caper/default_file_db'
+DEFAULT_FILE_DB_PREFIX = 'caper_file_db'
 DEFAULT_SINGULARITY_CACHEDIR = '~/.caper/singularity_cachedir'
 DEFAULT_CROMWELL_JAR = 'https://github.com/broadinstitute/cromwell/releases/download/42/cromwell-42.jar'
 DEFAULT_MYSQL_DB_IP = 'localhost'
@@ -30,169 +30,9 @@ DEFAULT_PORT = 8000
 DEFAULT_IP = 'localhost'
 DEFAULT_FORMAT = 'id,status,name,str_label,user,submission'
 DEFAULT_DEEPCOPY_EXT = 'json,tsv'
-DEFAULT_CAPER_CONF_CONTENTS = """[defaults]
-
-############ Minimum required parameters
-## Please read through carefully
-
-## Define file DB to use Cromwell's call-caching
-
-## IMPORTANT #########################################################
-## This DB file will grow fast to reach several GBs
-## Make sure that you have enough disk space for this file on the target directory.
-## IMPORTANT ########################################################
-
-## Call-caching is important for restarting failed workflows
-## File DB can only be accessed by one caper process (caper run or server)
-## i.e. you cannot run multiple caper run with one file DB
-## For such case, we recommend to use caper server and submit multiple workflows to it
-## You can disable file DB with '--no-file-db' or '-n'
-#file-db=~/.caper/default_file_db
-
-## DB timeout for both file DB and MySQL DB
-## If your DB file is large then you can see "db - Connection is not available" error
-## then try to increase this timeout
-#db-timeout=30000
-
-## Define to use 'caper server' and all client subcommands like 'caper submit'
-## This is not required for 'caper run'
-#port=8000
-
-## Define default backend (local, gcp, aws, slurm, sge, pbs)
-#backend=local
-
-## Define output directory if you want to run pipelines locally
-#out-dir=
-
-## Define if you want to run pipelines on Google Cloud Platform
-#gcp-prj=encode-dcc-1016
-#out-gcs-bucket=gs://encode-pipeline-test-runs/caper_out_project1
-
-## Define if you want to run pipelines on AWS
-#aws-batch-arn=arn:....
-#aws-region=us-west-1
-#out-s3-bucket=s3://encode-pipeline-test-runs/caper_out_project1
-
-## Define if you want to run pipelines on SLURM
-## Define partition or account or both according to your cluster's requirements
-## For example, Stanford requires a partition and SCG requires an account.
-#slurm-partition=akundaje
-#slurm-account=akundaje
-
-## Define if you want to run pipelines on SGE
-#sge-pe=shm
-
-## Define if your SGE cluster requires a queue
-#sge-queue=q
-
-## Define if your PBS cluster requires a queue
-#pbs-queue=q
-
-
-############# Caper settings
-## cromwell.jar java heap
-## java -Xmx for "caper server"
-#java-heap-server=7G
-
-## java -Xmx for "caper run"
-#java-heap-run=1G
-
-### Workflow settings
-#deepcopy-ext=json,tsv
-
-############# local backend
-## Singularity image will be pulled to this directory
-## if you don't specify this, then Singularity will pull image
-## from remote repo everytime for each task.
-## to prevent this overhead DEFINE IT
-## user's scratch is recommended
-#singularity-cachedir=~/.caper/singularity_cachedir
-
-## local singularity image will not be built before running
-## a workflow. this can result in conflicts between tasks
-## trying to write on the same image file.
-#no-build-singularity=True
-
-## all temporary files (including deepcopied data files,
-## backend conf, worflow_opts JSONs, ...)
-## will be written to this directory
-## DON'T USE /tmp. User's scratch directory is recommended
-#tmp-dir=
-
-############# Google Cloud Platform backend
-## comma-separated zones for GCP (e.g. us-west1-b,us-central1-b)
-#gcp-zones=
-
-#tmp-gcs-bucket=
-
-############# AWS backend
-#tmp-s3-bucket=
-
-## gsutil can work with s3 buckets it outperforms over aws s3 CLI
-#use-gsutil-over-aws-s3=True
-
-############# HTTP auth to download from private URLs (http://, https://)
-## username and password are exposed in a command line
-## so visible to other users on a local computer by 'ps' command
-#http-user=
-#http-password=
-
-## using cURL's ~/.netrc is more secure, we recommend to use it
-## keep ~/.netrc secure and use this at your own risk
-## see more details at
-## https://github.com/bagder/everything-curl/blob/master/usingcurl-netrc.md
-## for example of encode portal. look at the following .netrc contents
-## machine www.encodeproject.org
-## login ZSFDUCEJ
-## password YOUR_PASSWORD
-#use-netrc=True
-
-############# Cromwell's built-in HyperSQL database settings
-## disable file-db
-## Detach DB from Cromwell
-## you can run multiple workflows with 'caper run' command
-## but Caper will not be able re-use outputs from previous workflows
-#no-file-db=True
-
-############# MySQL database settings
-## both caper run/server modes will attach to MySQL db
-## uncomment/define all of the followings to use MySQL database
-#mysql-db-ip=
-#mysql-db-port=
-#mysql-db-user=cromwell
-#mysql-db-password=cromwell
-
-############# Cromwell general settings
-#cromwell=https://github.com/broadinstitute/cromwell/releases/download/42/cromwell-42.jar
-#max-concurrent-tasks=1000
-#max-concurrent-workflows=40
-#disable-call-caching=False
-#backend-file=
-
-## Cromwell server
-#ip=localhost
-
-############# SLURM backend
-#slurm-extra-param=
-
-############# SGE backend
-#sge-extra-param=
-
-############# PBS backend
-#pbs-extra-param=
-
-############# Misc. settings
-## list workflow format
-#format=id,status,name,str_label,user,submission
-
-## hide workflows submitted before
-## use the same date/time format as shown in "caper list"
-## e.g. 2019-06-13, 2019-06-13T10:07
-#hide-result-before=
-
-## for troubleshooting, show successully completed tasks too
-#show-completed-task=True
-"""
+DEFAULT_SERVER_HEARTBEAT_FILE = '~/.caper/default_server_heartbeat'
+DEFAULT_SERVER_HEARTBEAT_TIMEOUT_MS = 120000
+DEFAULT_CAPER_CONF_CONTENTS = "[defaults]\n\n"
 
 
 def parse_caper_arguments():
@@ -488,11 +328,22 @@ def parse_caper_arguments():
 
     parent_server_client = argparse.ArgumentParser(add_help=False)
     parent_server_client.add_argument(
-        '--port', default=DEFAULT_PORT,
+        '--port', default=DEFAULT_PORT, type=int,
         help='Port for Caper server')
     parent_server_client.add_argument(
         '--ip', default=DEFAULT_IP,
         help='IP address for Caper server')
+    parent_server_client.add_argument(
+        '--server-heartbeat-file',
+        default=DEFAULT_SERVER_HEARTBEAT_FILE,
+        help='Heartbeat file for Caper clients to get IP and port of a server')
+    parent_server_client.add_argument(
+        '--server-heartbeat-timeout',
+        default=DEFAULT_SERVER_HEARTBEAT_TIMEOUT_MS,
+        help='Timeout for a heartbeat file in Milliseconds. '
+             'A heartbeat file older than '
+             'this interval will be ignored.')
+
     parent_list = argparse.ArgumentParser(add_help=False)
     parent_list.add_argument(
         '-f', '--format', default=DEFAULT_FORMAT,
@@ -587,90 +438,11 @@ def parse_caper_arguments():
         'db_timeout',
         'max_retries',
         'max_concurrent_tasks',
-        'max_concurrent_workflows']:
+        'max_concurrent_workflows',
+        'server_heartbeat_timeout',
+        'port']:
         v = args_d.get(k)
         if v is not None and isinstance(v, str):
             args_d[k] = int(v)
-
-    docker = args_d.get('docker')
-    if docker is not None:
-        use_docker = True
-    else:
-        use_docker = False
-    if isinstance(docker, list):
-        if len(docker) > 0:
-            docker = docker[0]
-        else:
-            docker = None
-    elif isinstance(docker, str) and docker == '':
-        docker = None
-    args_d['docker'] = docker
-    args_d['use_docker'] = use_docker
-
-    singularity = args_d.get('singularity')
-    if singularity is not None:
-        use_singularity = True
-    else:
-        use_singularity = False
-    if isinstance(singularity, list):
-        if len(singularity) > 0:
-            singularity = singularity[0]
-        else:
-            singularity = None
-    elif isinstance(singularity, str) and singularity == '':
-        singularity = None
-    args_d['singularity'] = singularity
-    args_d['use_singularity'] = use_singularity
-
-    if use_docker and use_singularity:
-        raise Exception('--docker and --singularity are mutually exclusive')
-
-    # init some important path variables
-    if args_d.get('out_dir') is None:
-        args_d['out_dir'] = os.getcwd()
-
-    if args_d.get('tmp_dir') is None:
-        args_d['tmp_dir'] = os.path.join(args_d['out_dir'], '.caper_tmp')
-
-    if args_d.get('tmp_s3_bucket') is None:
-        if args_d.get('out_s3_bucket'):
-            args_d['tmp_s3_bucket'] = os.path.join(args_d['out_s3_bucket'],
-                                                   '.caper_tmp')
-    if args_d.get('tmp_gcs_bucket') is None:
-        if args_d.get('out_gcs_bucket'):
-            args_d['tmp_gcs_bucket'] = os.path.join(args_d['out_gcs_bucket'],
-                                                    '.caper_tmp')
-    backend = args_d.get('backend')
-    if backend is not None:
-        if backend == 'google':
-            backend = 'gcp'
-        elif backend == 'amazon':
-            backend = 'aws'
-        args_d['backend'] = backend
-
-    file_db = args_d.get('file_db')
-    if file_db is not None:
-        file_db = os.path.abspath(os.path.expanduser(file_db))
-        args_d['file_db'] = file_db
-    elif backend is None or backend == 'local':
-        basename = os.path.basename(DEFAULT_FILE_DB)
-        out_dir = args_d['out_dir']
-        args_d['file_db'] = os.path.join(out_dir, basename)
-        out_dir = args_d['out_dir']
-    else:
-        args_d['file_db'] = os.path.abspath(
-            os.path.expanduser(DEFAULT_FILE_DB))
-
-    singularity_cachedir = args_d.get('singularity_cachedir')
-    if singularity_cachedir is not None:
-        singularity_cachedir = os.path.abspath(
-            os.path.expanduser(singularity_cachedir))
-        args_d['singularity_cachedir'] = singularity_cachedir
-        os.makedirs(singularity_cachedir, exist_ok=True)
-
-    if args_d.get('str_label') is None:
-        if args_d.get('inputs') is not None:
-            basename = os.path.basename(args_d['inputs'])
-            args_d['str_label'] = os.path.splitext(basename)[0]
 
     return args_d

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -259,7 +259,7 @@ def parse_caper_arguments():
     group_file_db = parent_host.add_argument_group(
         title='HyperSQL file DB arguments')
     group_file_db.add_argument(
-        '--file-db', '-d', default=DEFAULT_FILE_DB,
+        '--file-db', '-d',
         help='Default DB file for Cromwell\'s built-in HyperSQL database.')
     group_file_db.add_argument(
         '--no-file-db', '-n', action='store_true',
@@ -640,10 +640,20 @@ def parse_caper_arguments():
         if args_d.get('out_gcs_bucket'):
             args_d['tmp_gcs_bucket'] = os.path.join(args_d['out_gcs_bucket'],
                                                     '.caper_tmp')
+    backend = args_d.get('backend')
+
     file_db = args_d.get('file_db')
     if file_db is not None:
         file_db = os.path.abspath(os.path.expanduser(file_db))
         args_d['file_db'] = file_db
+    elif backend is None or backend == 'local':
+        basename = os.path.basename(DEFAULT_FILE_DB)
+        out_dir = args_d['out_dir']
+        args_d['file_db'] = os.path.join(out_dir, basename)
+        out_dir = args_d['out_dir']
+    else:
+        args_d['file_db'] = os.path.abspath(
+            os.path.expanduser(DEFAULT_FILE_DB))
 
     singularity_cachedir = args_d.get('singularity_cachedir')
     if singularity_cachedir is not None:

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -12,7 +12,7 @@ import os
 from distutils.util import strtobool
 
 
-__version__ = '0.3.20'
+__version__ = '0.4.0'
 
 DEFAULT_JAVA_HEAP_SERVER = '7G'
 DEFAULT_JAVA_HEAP_RUN = '1G'

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -17,7 +17,6 @@ __version__ = '0.4.0'
 DEFAULT_JAVA_HEAP_SERVER = '7G'
 DEFAULT_JAVA_HEAP_RUN = '1G'
 DEFAULT_CAPER_CONF = '~/.caper/default.conf'
-DEFAULT_FILE_DB_PREFIX = 'caper_file_db'
 DEFAULT_SINGULARITY_CACHEDIR = '~/.caper/singularity_cachedir'
 DEFAULT_CROMWELL_JAR = 'https://github.com/broadinstitute/cromwell/releases/download/42/cromwell-42.jar'
 DEFAULT_MYSQL_DB_IP = 'localhost'
@@ -32,7 +31,7 @@ DEFAULT_FORMAT = 'id,status,name,str_label,user,submission'
 DEFAULT_DEEPCOPY_EXT = 'json,tsv'
 DEFAULT_SERVER_HEARTBEAT_FILE = '~/.caper/default_server_heartbeat'
 DEFAULT_SERVER_HEARTBEAT_TIMEOUT_MS = 120000
-DEFAULT_CAPER_CONF_CONTENTS = "[defaults]\n\n"
+DEFAULT_CAPER_CONF_CONTENTS = '\n\n'
 DYN_FLAGS = ['--singularity', '--docker']
 INVALID_EXT_FOR_DYN_FLAG = '.wdl'
 
@@ -95,8 +94,13 @@ def parse_caper_arguments():
         known_args.conf = os.path.expanduser(known_args.conf)
         if os.path.exists(known_args.conf):
             config = ConfigParser()
-            config.read([known_args.conf])
-            d = dict(config.items("defaults"))
+            with open(known_args.conf, 'r') as fp:
+                conf_contents = fp.read()
+            if '[defaults]' not in conf_contents.split('\n'):
+                conf_contents = '[defaults]\n' + conf_contents
+            print(conf_contents)
+            config.read_string(conf_contents)
+            d = dict(config.items('defaults'))
             # replace - with _
             defaults.update({k.replace('-', '_'): v for k, v in d.items()})
 

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -4,10 +4,37 @@
 
 BACKEND_GCP = 'gcp'
 BACKEND_AWS = 'aws'
-BACKEND_LOCAL = 'Local'  # must be CAPITAL L
+BACKEND_LOCAL = 'Local'  # should be CAPITAL L
 BACKEND_SLURM = 'slurm'
 BACKEND_SGE = 'sge'
 BACKEND_PBS = 'pbs'
+BACKENDS = [BACKEND_GCP, BACKEND_AWS, BACKEND_LOCAL, BACKEND_SLURM,
+    BACKEND_SGE, BACKEND_PBS]
+
+BACKEND_ALIAS_LOCAL = 'local'  # with small L
+BACKEND_ALIAS_GOOGLE = 'google'
+BACKEND_ALIAS_AMAZON = 'amazon'
+BACKEND_ALIAS_SHERLOCK = 'sherlock'
+BACKEND_ALIAS_SCG = 'scg'
+BACKEND_ALIASES = [BACKEND_ALIAS_LOCAL, BACKEND_ALIAS_GOOGLE, BACKEND_ALIAS_AMAZON, BACKEND_ALIAS_SHERLOCK,
+    BACKEND_ALIAS_SCG]
+
+BACKENDS_WITH_ALIASES = BACKENDS + BACKEND_ALIASES
+    
+
+
+def get_backend(backend):
+    if backend == BACKEND_ALIAS_GOOGLE:
+        backend = BACKEND_GCP
+    elif backend == BACKEND_ALIAS_AMAZON:
+        backend = BACKEND_AWS
+    elif backend == BACKEND_ALIAS_SHERLOCK:
+        backend = BACKEND_SLURM
+    elif backend == BACKEND_ALIAS_SCG:
+        backend = BACKEND_SLURM
+    if backend not in BACKENDS:
+        raise Exception('Unsupported backend: {}'.format(backend))
+    return backend
 
 
 class CaperBackendCommon(dict):
@@ -94,7 +121,7 @@ class CaperBackendDatabase(dict):
             if file_db is not None:
                 self['database']['db'] = {
                     'url': 'jdbc:hsqldb:file:{};shutdown=false;'
-                    'hsqldb.tx=mvcc'.format(file_db)
+                    'hsqldb.tx=mvcc;hsqldb.lob_compressed=true'.format(file_db)
                 }
                 if db_timeout is not None:
                     self['database']['db']['connectionTimeout'] = db_timeout

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -20,7 +20,6 @@ BACKEND_ALIASES = [BACKEND_ALIAS_LOCAL, BACKEND_ALIAS_GOOGLE, BACKEND_ALIAS_AMAZ
     BACKEND_ALIAS_SCG]
 
 BACKENDS_WITH_ALIASES = BACKENDS + BACKEND_ALIASES
-    
 
 
 def get_backend(backend):
@@ -32,6 +31,8 @@ def get_backend(backend):
         backend = BACKEND_SLURM
     elif backend == BACKEND_ALIAS_SCG:
         backend = BACKEND_SLURM
+    elif backend == BACKEND_ALIAS_LOCAL:
+        backend = BACKEND_LOCAL
     if backend not in BACKENDS:
         raise Exception('Unsupported backend: {}'.format(backend))
     return backend

--- a/caper/caper_check.py
+++ b/caper/caper_check.py
@@ -8,6 +8,9 @@ Author:
 import os
 
 
+DEFAULT_FILE_DB_PREFIX = 'caper_file_db'
+
+
 def check_caper_conf(args_d):
     """Check arguments/configuration for Caper
     """

--- a/caper/caper_check.py
+++ b/caper/caper_check.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""CaperCheck: Caper arguments/configuration checker
+
+Author:
+    Jin Lee (leepc12@gmail.com) at ENCODE-DCC
+"""
+
+import os
+
+
+def check_caper_conf(args_d):
+    """Check arguments/configuration for Caper
+    """
+    docker = args_d.get('docker')
+    if docker is not None:
+        use_docker = True
+    else:
+        use_docker = False
+    if isinstance(docker, list):
+        if len(docker) > 0:
+            docker = docker[0]
+        else:
+            docker = None
+    elif isinstance(docker, str) and docker == '':
+        docker = None
+    args_d['docker'] = docker
+    args_d['use_docker'] = use_docker
+
+    singularity = args_d.get('singularity')
+    if singularity is not None:
+        use_singularity = True
+    else:
+        use_singularity = False
+    if isinstance(singularity, list):
+        if len(singularity) > 0:
+            singularity = singularity[0]
+        else:
+            singularity = None
+    elif isinstance(singularity, str) and singularity == '':
+        singularity = None
+    args_d['singularity'] = singularity
+    args_d['use_singularity'] = use_singularity
+
+    if use_docker and use_singularity:
+        raise Exception('--docker and --singularity are mutually exclusive')
+
+    # init some important path variables
+    if args_d.get('out_dir') is None:
+        args_d['out_dir'] = os.getcwd()
+
+    if args_d.get('tmp_dir') is None:
+        args_d['tmp_dir'] = os.path.join(args_d['out_dir'], '.caper_tmp')
+
+    if args_d.get('tmp_s3_bucket') is None:
+        if args_d.get('out_s3_bucket'):
+            args_d['tmp_s3_bucket'] = os.path.join(args_d['out_s3_bucket'],
+                                                   '.caper_tmp')
+    if args_d.get('tmp_gcs_bucket') is None:
+        if args_d.get('out_gcs_bucket'):
+            args_d['tmp_gcs_bucket'] = os.path.join(args_d['out_gcs_bucket'],
+                                                    '.caper_tmp')
+    backend = args_d.get('backend')
+    if backend is not None:
+        if backend == 'google':
+            backend = 'gcp'
+        elif backend == 'amazon':
+            backend = 'aws'
+        args_d['backend'] = backend
+
+    file_db = args_d.get('file_db')
+    if file_db is not None:
+        file_db = os.path.abspath(os.path.expanduser(file_db))
+    else:
+        basename = DEFAULT_FILE_DB_PREFIX
+        out_dir = args_d['out_dir']
+        inputs = args_d.get('inputs')
+        if inputs is not None:
+            inputs_wo_ext, ext = os.path.splitext(
+                os.path.basename(inputs))
+            basename += '.' + inputs_wo_ext
+        file_db = os.path.join(out_dir, basename)
+    args_d['file_db'] = file_db
+
+    singularity_cachedir = args_d.get('singularity_cachedir')
+    if singularity_cachedir is not None:
+        singularity_cachedir = os.path.abspath(
+            os.path.expanduser(singularity_cachedir))
+        args_d['singularity_cachedir'] = singularity_cachedir
+        os.makedirs(singularity_cachedir, exist_ok=True)
+
+    if args_d.get('str_label') is None:
+        if args_d.get('inputs') is not None:
+            basename = os.path.basename(args_d['inputs'])
+            args_d['str_label'] = os.path.splitext(basename)[0]
+
+    return args_d

--- a/caper/cromwell_rest_api.py
+++ b/caper/cromwell_rest_api.py
@@ -262,6 +262,8 @@ class CromwellRestAPI(object):
         except Exception as e:
             # traceback.print_exc()
             print(e)
+            print('Help: cannot connect to server. '\
+                  'Check if server is dead or still spinning up.')
             sys.exit(1)
 
         if resp.ok:


### PR DESCRIPTION
1) Deprecated old flags `--use-docker` and `--use-singularity`.

`--docker` and `--singularity` can work as flags too. 
```
$ caper run atac.wdl --docker  # this will use docker image defined in WDL
$ caper run atac.wdl --docker docker_image_location
```

2) `caper init`
Choose a platform and caper will auto-generate default configuration file (`~/.caper/default.conf`) with only required parameters for a chosen platform.
```
$ caper init sherlock
```

3) Others
- A file DB is now compressed.
- Better error checking and troubleshooting.