### PR TITLE
Pip 783 support presigned url

### DIFF
--- a/caper/__init__.py
+++ b/caper/__init__.py
@@ -1,0 +1,3 @@
+import caper.caper_args
+
+__version__ = caper.caper_args.__version__

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -19,7 +19,7 @@ from .caper_backend import BACKEND_ALIAS_GOOGLE, BACKEND_ALIAS_AMAZON
 from .caper_backend import BACKEND_ALIAS_SHERLOCK, BACKEND_ALIAS_SCG
 
 
-__version__ = '0.4.1'
+__version__ = '0.5.0'
 
 DEFAULT_JAVA_HEAP_SERVER = '7G'
 DEFAULT_JAVA_HEAP_RUN = '1G'

--- a/caper/caper_uri.py
+++ b/caper/caper_uri.py
@@ -620,8 +620,7 @@ class CaperURI(object):
                     ['gsutil', '-q', 'signurl', '-d',
                      str(CaperURI.DURATION_SEC_PRESIGNED_URL_GCS) + 's',
                      CaperURI.GCP_PRIVATE_KEY_FILE,
-                     self._uri],
-                    stderr=PIPE).decode()
+                     self._uri]).decode()
                 # example: URL     HTTP Method     Expiration      Signed URL
                 # taking fourth column of line 2
                 url = s.strip('\n').split('\n')[1].split('\t')[3]
@@ -640,8 +639,7 @@ class CaperURI(object):
                 url = check_output(
                     ['aws', 's3', 'presign', '--expires-in',
                      CaperURI.DURATION_SEC_PRESIGNED_URL_S3,
-                     self._uri],
-                    stderr=PIPE).decode().strip('\n')
+                     self._uri]).decode().strip('\n')
                 if CaperURI.VERBOSE:
                     print('[CaperURI] presigned s3 url for {dur} sec. '
                           'src: {src}, url: {url}'.format(

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 import setuptools
-from caper import caper_args
+import caper
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name='caper',
-    version=caper_args.__version__,
+    version=caper.__version__,
     python_requires='>3.4.1',
     scripts=['bin/caper', 'mysql/run_mysql_server_docker.sh',
              'mysql/run_mysql_server_singularity.sh'],
@@ -22,5 +22,5 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
     ],
-    install_requires=['pyhocon', 'requests']
+    install_requires=['pyhocon', 'requests', 'pyopenssl']
 )


### PR DESCRIPTION
Can convert `gs://`, `s3://` URIs to presigned URLs.
   - Also can convert local path into a URL.
   - This is an update for Croo to be able to generate presigned URLs for UCSC genome browser tracks
