### PR TITLE
Dev12

### DIFF
--- a/caper/caper.py
+++ b/caper/caper.py
@@ -1034,7 +1034,7 @@ class Caper(object):
                   singularity)
             cmd = ['singularity', 'exec', singularity,
                    'echo', '[Caper] building done.']
-            env=os.environ.copy()
+            env = os.environ.copy()
             if self._singularity_cachedir is not None \
                     and 'SINGULARITY_CACHEDIR' not in env:
                 env['SINGULARITY_CACHEDIR'] = self._singularity_cachedir

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -1034,11 +1034,10 @@ class Caper(object):
                   singularity)
             cmd = ['singularity', 'exec', singularity,
                    'echo', '[Caper] building done.']
+            env=os.environ.copy()
             if self._singularity_cachedir is not None \
-                    and 'SINGULARITY_CACHEDIR' not in os.environ:
-                env = {'SINGULARITY_CACHEDIR': self._singularity_cachedir}
-            else:
-                env = None
+                    and 'SINGULARITY_CACHEDIR' not in env:
+                env['SINGULARITY_CACHEDIR'] = self._singularity_cachedir
             return check_call(cmd, env=env)
 
         print('[Caper] skip building local singularity image.')

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -821,6 +821,7 @@ class Caper(object):
             # ignore imports as HTTP URL or absolute PATH
             if CaperURI(imp).uri_type == URI_LOCAL \
                     or not os.path.isabs(imp):
+                files_to_zip.append(imp)
                 # download imports relative to WDL (which can exists remotely)
                 wdl_dirname = os.path.dirname(self._wdl)
                 c_imp_ = CaperURI(os.path.join(wdl_dirname, imp))

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -70,6 +70,8 @@ sge-pe=
 tmp-dir=
 """
 DEFAULT_CONF_CONTENTS_PBS = """backend=pbs
+
+tmp-dir=
 """
 DEFAULT_CONF_CONTENTS_AWS = """backend=aws
 aws-batch-arn=

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -19,10 +19,10 @@ from .caper_backend import BACKEND_ALIAS_GOOGLE, BACKEND_ALIAS_AMAZON
 from .caper_backend import BACKEND_ALIAS_SHERLOCK, BACKEND_ALIAS_SCG
 
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 
-DEFAULT_JAVA_HEAP_SERVER = '7G'
-DEFAULT_JAVA_HEAP_RUN = '1G'
+DEFAULT_JAVA_HEAP_SERVER = '10G'
+DEFAULT_JAVA_HEAP_RUN = '2G'
 DEFAULT_CAPER_CONF = '~/.caper/default.conf'
 DEFAULT_SINGULARITY_CACHEDIR = '~/.caper/singularity_cachedir'
 DEFAULT_CROMWELL_JAR = 'https://github.com/broadinstitute/cromwell/releases/download/42/cromwell-42.jar'


### PR DESCRIPTION
Bug fixes
  - Subworkflow WDLs are not zipped
  - issue #26  (wrong export of `os.environ`)

Change of default parameters:
  - `java-heap-server`: 7G -> 10G
  - `java-heap-run`: 1G -> 2G