### PR TITLE
install cromwell/womtool JARs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and 
 	export PATH=$PATH:~/.local/bin
 	```
 
-5) Choose a platform from the following table and initialize Caper. This will create a default Caper configuration file `~/.caper/default.conf`, which have only required parameters for each platform. There are special platforms for Stanford Sherlock/SCG users.
+5) Choose a platform from the following table and initialize Caper. This will create a default Caper configuration file `~/.caper/default.conf`, which have only required parameters for each platform. There are special platforms for Stanford Sherlock/SCG users. This will also install Cromwell/Womtool JARs on `~/.caper`. Downloading those files can take up to 10 minutes. Once they are installed, Caper can completely work offline with local data files.
+
 	```bash
 	$ caper init [PLATFORM]
 	```

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -28,6 +28,8 @@ DEFAULT_CAPER_CONF = '~/.caper/default.conf'
 DEFAULT_SINGULARITY_CACHEDIR = '~/.caper/singularity_cachedir'
 DEFAULT_CROMWELL_JAR = 'https://github.com/broadinstitute/cromwell/releases/download/47/cromwell-47.jar'
 DEFAULT_WOMTOOL_JAR = 'https://github.com/broadinstitute/cromwell/releases/download/47/womtool-47.jar'
+DEFAULT_CROMWELL_JAR_INSTALL_DIR = '~/.caper/cromwell_jar'
+DEFAULT_WOMTOOL_JAR_INSTALL_DIR = '~/.caper/womtool_jar'
 DEFAULT_DB = CaperBackendDatabase.DB_TYPE_IN_MEMORY
 DEFAULT_MYSQL_DB_IP = 'localhost'
 DEFAULT_MYSQL_DB_PORT = 3306
@@ -140,7 +142,38 @@ def process_dyn_flags(remaining_args, dyn_flags,
     return remaining_args
 
 
+def install_cromwell_jar(uri):
+    """Download cromwell-X.jar
+    """
+    from .caper_uri import CaperURI, URI_LOCAL
+    cu = CaperURI(uri)
+    if cu.uri_type == URI_LOCAL:
+        return cu.get_uri()
+    print('Downloading Cromwell JAR... {f}'.format(f=uri), file=sys.stderr)
+    path = os.path.join(
+        os.path.expanduser(DEFAULT_CROMWELL_JAR_INSTALL_DIR),
+        os.path.basename(uri))
+    return cu.copy(target_uri=path)
+
+
+def install_womtool_jar(uri):
+    """Download womtool-X.jar
+    """
+    from .caper_uri import CaperURI, URI_LOCAL
+    cu = CaperURI(uri)
+    if cu.uri_type == URI_LOCAL:
+        return cu.get_uri()
+    print('Downloading Womtool JAR... {f}'.format(f=uri), file=sys.stderr)
+    path = os.path.join(
+        os.path.expanduser(DEFAULT_WOMTOOL_JAR_INSTALL_DIR),
+        os.path.basename(uri))
+    return cu.copy(target_uri=path)
+
+
 def init_caper_conf(args):
+    """Initialize conf file for a given platform.
+    Also, download/install Cromwell/Womtool JARs.
+    """
     backend = args.get('platform')
     assert(backend in BACKENDS_WITH_ALIASES)
     if backend in (BACKEND_LOCAL, BACKEND_ALIAS_LOCAL):
@@ -165,6 +198,12 @@ def init_caper_conf(args):
     conf_file = os.path.expanduser(args.get('conf'))
     with open(conf_file, 'w') as fp:
         fp.write(contents + '\n')
+        fp.write('{key}={val}\n'.format(
+            key='cromwell',
+            val=install_cromwell_jar(DEFAULT_CROMWELL_JAR)))
+        fp.write('{key}={val}\n'.format(
+            key='womtool',
+            val=install_womtool_jar(DEFAULT_WOMTOOL_JAR)))
 
 
 def parse_caper_arguments():

--- a/caper/caper_uri.py
+++ b/caper/caper_uri.py
@@ -203,24 +203,20 @@ class CaperURI(object):
     LOCK_MAX_ITER = 100
 
     def __init__(self, uri_or_path):
-        if CaperURI.TMP_DIR is None:
+        if CaperURI.TMP_DIR is not None and \
+            not CaperURI.TMP_DIR.endswith('/'):
             raise Exception(
-                'Call init_caper_uri() first '
-                'to initialize CaperURI. TMP_DIR must be '
-                'specified.')
-        elif not CaperURI.TMP_DIR.endswith('/'):
-            raise Exception(
-                'CaperURI.TMP_DIR must ends '
+                'CaperURI.TMP_DIR must end '
                 'with a slash (/).')
         if CaperURI.TMP_S3_BUCKET is not None and \
            not CaperURI.TMP_S3_BUCKET.endswith('/'):
             raise Exception(
-                'CaperURI.TMP_S3_BUCKET must ends '
+                'CaperURI.TMP_S3_BUCKET must end '
                 'with a slash (/).')
         if CaperURI.TMP_GCS_BUCKET is not None and \
            not CaperURI.TMP_GCS_BUCKET.endswith('/'):
             raise Exception(
-                'CaperURI.TMP_GCS_BUCKET must ends '
+                'CaperURI.TMP_GCS_BUCKET must end '
                 'with a slash (/).')
 
         self._uri = uri_or_path


### PR DESCRIPTION
`caper init` downloads Cromwell/Womtool JARs and adds them to Caper's default conf file `~/.caper/default.conf` (or whatever defined with `-c`).

Example `~/.caper/default.conf` after `caper init local`.
```
backend=local

# DO NOT use /tmp here
# Caper stores all important temp files and cached big data files here
tmp-dir=

cromwell=/users/leepc12/.caper/cromwell_jar/cromwell-47.jar
womtool=/users/leepc12/.caper/womtool_jar/womtool-47.jar
```

This prevents Caper from sending requests to a github server (hosting Cromwell/Womtool JAR URLs) for every `caper run` or `caper submit`.
