### PR TITLE
cromwell_rest_api can get labels too when GETTING workflows

### DIFF
--- a/caper/caper.py
+++ b/caper/caper.py
@@ -490,14 +490,16 @@ class Caper(object):
                 if f == 'workflow_id':
                     row.append(str(workflow_id))
                 elif f == 'str_label':
-                    lbl = self._cromwell_rest_api.get_label(
-                        workflow_id,
-                        Caper.KEY_CAPER_STR_LABEL)
+                    if 'labels' in w and Caper.KEY_CAPER_STR_LABEL in w['labels']:
+                        lbl = w['labels'][Caper.KEY_CAPER_STR_LABEL]
+                    else:
+                        lbl = None
                     row.append(str(lbl))
                 elif f == 'user':
-                    lbl = self._cromwell_rest_api.get_label(
-                        workflow_id,
-                        Caper.KEY_CAPER_USER)
+                    if 'labels' in w and Caper.KEY_CAPER_USER in w['labels']:
+                        lbl = w['labels'][Caper.KEY_CAPER_USER]
+                    else:
+                        lbl = None
                     row.append(str(lbl))
                 else:
                     row.append(str(w[f] if f in w else None))

--- a/caper/cromwell_rest_api.py
+++ b/caper/cromwell_rest_api.py
@@ -20,6 +20,9 @@ class CromwellRestAPI(object):
     ENDPOINT_ABORT = '/api/workflows/v1/{wf_id}/abort'
     ENDPOINT_RELEASE_HOLD = '/api/workflows/v1/{wf_id}/releaseHold'
     KEY_LABEL = 'cromwell_rest_api_label'
+    PARAMS_WORKFLOWS = {
+        'additionalQueryResultFields': 'labels'
+    }
 
     def __init__(self, ip='localhost', port=8000,
                  user=None, password=None, verbose=False):
@@ -198,7 +201,8 @@ class CromwellRestAPI(object):
             List of matched workflow JSONs
         """
         r = self.__request_get(
-            CromwellRestAPI.ENDPOINT_WORKFLOWS)
+            CromwellRestAPI.ENDPOINT_WORKFLOWS,
+            params=CromwellRestAPI.PARAMS_WORKFLOWS)
         if r is None:
             return None
         workflows = r['results']
@@ -215,8 +219,8 @@ class CromwellRestAPI(object):
                         break
             if w['id'] in matched:
                 continue
-            if labels is not None:
-                labels_ = self.get_labels(w['id'])
+            if labels is not None and 'labels' in w:
+                labels_ = w['labels']
                 for k, v in labels:
                     if k in labels_:
                         v_ = labels_[k]
@@ -246,7 +250,7 @@ class CromwellRestAPI(object):
         else:
             self._auth = None
 
-    def __request_get(self, endpoint):
+    def __request_get(self, endpoint, params=None):
         """GET request
 
         Returns:
@@ -257,7 +261,7 @@ class CromwellRestAPI(object):
                 port=self._port) + endpoint
         try:
             resp = requests.get(
-                url, auth=self._auth,
+                url, auth=self._auth, params=params,
                 headers={'accept': 'application/json'})
         except Exception as e:
             # traceback.print_exc()


### PR DESCRIPTION
Caper now can get labels of all workflows with just one query. In old versions of Cromwell, Caper had to send N+1 queries to get labels of N workflows.

https://encodedcc.atlassian.net/browse/PIP-924