### PR TITLE
Pip 925 heartbeat file

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -217,6 +217,10 @@ We highly recommend to use a default configuration file described in the section
 	:-----|:-----|:-----|:-----
 	ip|--ip|localhost|Cromwell server IP address or hostname
 	port|--port|8000|Cromwell server port
+	no-server-heartbeat|--no-server-heartbeat||Flag to disable server heartbeat file.
+	server-heartbeat-file|--server-heartbeat-file|`~/.caper/default_server_heartbeat`|Heartbeat file for Caper clients to get IP and port of a server.
+	server-heartbeat-timeout|--server-heartbeat-timeout|120000|Timeout for a heartbeat file in Milliseconds.
+
 	cromwell|--cromwell|[cromwell-40.jar](https://github.com/broadinstitute/cromwell/releases/download/40/cromwell-40.jar)|Path or URL for Cromwell JAR file
 	max-concurrent-tasks|--max-concurrent-tasks|1000|Maximum number of concurrent tasks
 	max-concurrent-workflows|--max-concurrent-workflows|40|Maximum number of concurrent workflows

--- a/DETAILS.md
+++ b/DETAILS.md
@@ -41,6 +41,19 @@ list     | WF_ID or STR_LABEL |List submitted workflows on a Cromwell server
 metadata | WF_ID or STR_LABEL |Retrieve metadata JSONs for workflows
 debug, troubleshoot | WF_ID, STR_LABEL or<br>METADATA_JSON_FILE |Analyze reason for errors
 
+* `init`: To initialize Caper on a given platform. This command also downloads Cromwell/Womtool JARs so that Caper can work completely offline with local data files.
+
+	**Platform**|**Description**
+	:--------|:-----
+	sherlock | Stanford Sherlock cluster (SLURM)
+	scg | Stanford SCG cluster (SLURM)
+	gcp | Google Cloud Platform
+	aws | Amazon Web Service
+	local | General local computer
+	sge | HPC with Sun GridEngine cluster engine
+	pbs | HPC with PBS cluster engine
+	slurm | HPC with SLURM cluster engine
+
 * `run`: To run a single workflow. A string label `-s` is optional and useful for other subcommands to indentify a workflow.
 
 	```bash

--- a/README.md
+++ b/README.md
@@ -201,6 +201,43 @@ $ cd [OUTPUT_DIR]  # make a separate directory for each workflow
 $ caper run [WDL] -i [INPUT_JSON]
 ```
 
+
+## Caper server heartbeat (running multiple servers)
+
+Caper server writes a heartbeat file (specified by `--server-heartbeat-file`) on every 120 seconds (controlled by `--server-heartbeat-timeout`). This file has simply an IP(hostname)/PORT pair of the running `caper server`.
+
+Example heartbeat file:
+```bash
+$ cat ~/.caper/default_server_heartbeat
+kadru.stanford.edu:8000
+```
+
+This heartbeat file is useful when users don't want to find IP(hostname)/PORT of a running `caper server` especially when they `qsub`bed or `sbatch`ed `caper server` on their clusters. For such cases, IP (hostname of node/instance) of the server is later determined after the cluster engine starts the submitted `caper server` job and it's annoying for users to find the IP (hostname) of the running server with `qstat` or `squeue` and add it to every Caper's client-side subcommands: e.g. `caper list --ip node_1 --port 8001`.
+
+Therefore, Caper defaults to use this heartbeat file (can be disabled by a flag `--no-server-heartbeat`). So If client-side caper functions like `caper list` and `caper metadata` finds this heartbeat file and automatically parse it to get an IP/PORT pair, which overrides `--ip` and `--port`.
+
+However, there can be a conflict if users want to run multiple `caper server`s on the same machine (or multiple machines sharing the same caper configuration directory `~/.caper/` and hence the same heartbeat file).
+
+Users can simply disable this heartbeat feature by adding the following line to their configuration file: e.g. `~/.caper/default.conf`.
+```bash
+no-server-heartbeat=True
+```
+
+Then start multiple servers with different port and DB (for example of MySQL). Make sure that each server uses a different DB (file or MySQL server port, whatever...) since there is no point of using multiple Caper servers with the same DB. For example of MySQL, don’t forget to spin up multiple MySQL servers with different ports.
+
+```bash
+$ caper server --port 8000 --mysql-db-port 3306 ... &
+$ caper server --port 8001 --mysql-db-port 3307 ... &
+$ caper server --port 8002 --mysql-db-port 3308 ... &
+```
+
+Send queries to a specific server.
+```bash
+$ caper list --port 8000
+$ caper list --port 8001
+$ caper list --port 8002
+```
+
 ## Metadata database
 
 If you are not interested in resuming failed workflows skip this section.

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ $ caper run [WDL] -i [INPUT_JSON]
 
 ## Caper server heartbeat (running multiple servers)
 
-Caper server writes a heartbeat file (specified by `--server-heartbeat-file`) on every 120 seconds (controlled by `--server-heartbeat-timeout`). This file has simply an IP(hostname)/PORT pair of the running `caper server`.
+Caper server writes a heartbeat file (specified by `--server-heartbeat-file`) on every 120 seconds (controlled by `--server-heartbeat-timeout`). This file will contain an IP(hostname)/PORT pair of the running `caper server`.
 
 Example heartbeat file:
 ```bash
@@ -212,18 +212,16 @@ $ cat ~/.caper/default_server_heartbeat
 kadru.stanford.edu:8000
 ```
 
-This heartbeat file is useful when users don't want to find IP(hostname)/PORT of a running `caper server` especially when they `qsub`bed or `sbatch`ed `caper server` on their clusters. For such cases, IP (hostname of node/instance) of the server is later determined after the cluster engine starts the submitted `caper server` job and it's annoying for users to find the IP (hostname) of the running server with `qstat` or `squeue` and add it to every Caper's client-side subcommands: e.g. `caper list --ip node_1 --port 8001`.
+This heartbeat file is useful when users don't want to find IP(hostname)/PORT of a running `caper server` especially when they `qsub`bed or `sbatch`ed `caper server` on their clusters. For such cases, IP (hostname of node/instance) of the server is later determined after the cluster engine starts the submitted `caper server` job and it's inconvenient for the users to find the IP (hostname) of the running server manually with `qstat` or `squeue` and add it back to Caper's configuration file `~/.caper/default.conf`.
 
-Therefore, Caper defaults to use this heartbeat file (can be disabled by a flag `--no-server-heartbeat`). So If client-side caper functions like `caper list` and `caper metadata` finds this heartbeat file and automatically parse it to get an IP/PORT pair, which overrides `--ip` and `--port`.
+Therefore, Caper defaults to use this heartbeat file (can be disabled by a flag `--no-server-heartbeat`). So if client-side caper functions like `caper list` and `caper metadata` finds this heartbeat file and automatically parse it to get an IP/PORT pair.
 
-However, there can be a conflict if users want to run multiple `caper server`s on the same machine (or multiple machines sharing the same caper configuration directory `~/.caper/` and hence the same heartbeat file).
-
-Users can simply disable this heartbeat feature by adding the following line to their configuration file: e.g. `~/.caper/default.conf`.
+However, there can be a conflict if users want to run multiple `caper server`s on the same machine (or multiple machines sharing the same caper configuration directory `~/.caper/` and hence the same default heartbeat file). For such cases, users can disable this heartbeat feature by adding the following line to their configuration file: e.g. `~/.caper/default.conf`.
 ```bash
 no-server-heartbeat=True
 ```
 
-Then start multiple servers with different port and DB (for example of MySQL). Make sure that each server uses a different DB (file or MySQL server port, whatever...) since there is no point of using multiple Caper servers with the same DB. For example of MySQL, don’t forget to spin up multiple MySQL servers with different ports.
+Then start multiple servers with different port and DB (for example of MySQL). Users should make sure that each server uses a different DB (file or MySQL server port, whatever...) since there is no point of using multiple Caper servers with the same DB. For example of MySQL, users should not forget to spin up multiple MySQL servers with different ports.
 
 ```bash
 $ caper server --port 8000 --mysql-db-port 3306 ... &

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -88,6 +88,7 @@ class Caper(object):
             action=args.get('action'),
             ip=args.get('ip'),
             port=args.get('port'),
+            no_server_hearbeat=args.get('no_server_heartbeat'),
             server_hearbeat_file=args.get('server_heartbeat_file'),
             server_hearbeat_timeout=args.get('server_heartbeat_timeout'))
 
@@ -531,8 +532,10 @@ class Caper(object):
             Caper.__troubleshoot(metadata, self._show_completed_task)
 
     def __init_cromwell_rest_api(self, action, ip, port,
+                                 no_server_hearbeat,
                                  server_hearbeat_file,
                                  server_hearbeat_timeout):
+        self._no_server_hearbeat = no_server_hearbeat
         self._server_hearbeat_file = server_hearbeat_file
         self._ip, self._port = \
             self.__read_heartbeat_file(action, ip, port, server_hearbeat_timeout)
@@ -541,7 +544,7 @@ class Caper(object):
             ip=self._ip, port=self._port, verbose=False)
 
     def __read_heartbeat_file(self, action, ip, port, server_hearbeat_timeout):
-        if self._server_hearbeat_file is not None:
+        if not self._no_server_hearbeat and self._server_hearbeat_file is not None:
             self._server_hearbeat_file = os.path.expanduser(
                 self._server_hearbeat_file)
             if action != 'server':
@@ -556,10 +559,11 @@ class Caper(object):
                 except:
                     print('[Caper] Warning: failed to read server_heartbeat_file',
                           self._server_hearbeat_file)
+        print(self._no_server_hearbeat, self._server_hearbeat_file, ip, port)
         return ip, port
 
     def __write_heartbeat_file(self):
-        if self._server_hearbeat_file is not None:
+        if not self._no_server_hearbeat and self._server_hearbeat_file is not None:
             while True:
                 try:
                     print('[Caper] Writing heartbeat',

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -553,6 +553,9 @@ def parse_caper_arguments():
         '--ip', default=DEFAULT_IP,
         help='IP address for Caper server')
     parent_server_client.add_argument(
+        '--no-server-heartbeat', action='store_true',
+        help='Disable server heartbeat file.')
+    parent_server_client.add_argument(
         '--server-heartbeat-file',
         default=DEFAULT_SERVER_HEARTBEAT_FILE,
         help='Heartbeat file for Caper clients to get IP and port of a server')
@@ -645,6 +648,7 @@ def parse_caper_arguments():
     # string to boolean
     for k in [
         'dry_run',
+        'no_server_heartbeat',
         'disable_call_caching',
         'use_gsutil_over_aws_s3',
         'hold',


### PR DESCRIPTION
Added documentation for heartbeat feature (automatically find IP/PORT of caper server for caper client subcommands). Added a parameter to disable Caper's heartbeat feature (to run multiple caper server on one (or multiple machines sharing the same heartbeat file).

https://encodedcc.atlassian.net/browse/PIP-925