### PR TITLE
Pip 926 refactor for caper init

### DIFF
--- a/caper/caper.py
+++ b/caper/caper.py
@@ -561,7 +561,6 @@ class Caper(object):
                 except:
                     print('[Caper] Warning: failed to read server_heartbeat_file',
                           self._server_hearbeat_file)
-        print(self._no_server_hearbeat, self._server_hearbeat_file, ip, port)
         return ip, port
 
     def __write_heartbeat_file(self):

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -29,7 +29,9 @@ from subprocess import Popen, check_call, PIPE, CalledProcessError
 from datetime import datetime
 
 from .dict_tool import merge_dict
-from .caper_args import parse_caper_arguments, install_cromwell_jar, install_womtool_jar
+from .caper_args import parse_caper_arguments
+from .caper_init import init_caper_conf, install_cromwell_jar, install_womtool_jar
+
 from .caper_check import check_caper_conf
 from .cromwell_rest_api import CromwellRestAPI
 from .caper_uri import URI_S3, URI_GCS, URI_LOCAL, \
@@ -1231,6 +1233,10 @@ def main():
     # parse arguments
     #   note that args is a dict
     args = parse_caper_arguments()
+    action = args['action']
+    if action == 'init':
+        init_caper_conf(args)
+        sys.exit(0)
     args = check_caper_conf(args)
 
     # init caper uri to transfer files across various storages
@@ -1245,10 +1251,9 @@ def main():
         use_gsutil_over_aws_s3=args.get('use_gsutil_over_aws_s3'),
         verbose=True)
 
-    # init caper: taking all args at init step
+    # initialize caper: taking all args at init step
     c = Caper(args)
 
-    action = args['action']
     if action == 'run':
         c.run()
     elif action == 'server':

--- a/caper/caper_check.py
+++ b/caper/caper_check.py
@@ -9,6 +9,7 @@ import os
 from .caper_backend import BACKENDS, BACKEND_SLURM, get_backend
 
 DEFAULT_FILE_DB_PREFIX = 'caper_file_db'
+DEFAULT_CAPER_TMP_DIR_SUFFIX = '.caper_tmp'
 
 
 def check_caper_conf(args_d):
@@ -57,16 +58,16 @@ def check_caper_conf(args_d):
         args_d['out_dir'] = os.getcwd()
 
     if args_d.get('tmp_dir') is None:
-        args_d['tmp_dir'] = os.path.join(args_d['out_dir'], '.caper_tmp')
+        args_d['tmp_dir'] = os.path.join(args_d['out_dir'], DEFAULT_CAPER_TMP_DIR_SUFFIX)
 
     if args_d.get('tmp_s3_bucket') is None:
         if args_d.get('out_s3_bucket'):
             args_d['tmp_s3_bucket'] = os.path.join(args_d['out_s3_bucket'],
-                                                   '.caper_tmp')
+                                                   DEFAULT_CAPER_TMP_DIR_SUFFIX)
     if args_d.get('tmp_gcs_bucket') is None:
         if args_d.get('out_gcs_bucket'):
             args_d['tmp_gcs_bucket'] = os.path.join(args_d['out_gcs_bucket'],
-                                                    '.caper_tmp')
+                                                    DEFAULT_CAPER_TMP_DIR_SUFFIX)
     file_db = args_d.get('file_db')
     if file_db is not None:
         file_db = os.path.abspath(os.path.expanduser(file_db))

--- a/caper/caper_init.py
+++ b/caper/caper_init.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Functions for caper init subcommand
+
+Author:
+    Jin Lee (leepc12@gmail.com) at ENCODE-DCC
+"""
+
+import os
+import sys
+from .caper_backend import BACKENDS, BACKENDS_WITH_ALIASES
+from .caper_backend import BACKEND_GCP, BACKEND_AWS, BACKEND_LOCAL
+from .caper_backend import BACKEND_SLURM, BACKEND_SGE, BACKEND_PBS
+from .caper_backend import BACKEND_ALIAS_LOCAL
+from .caper_backend import BACKEND_ALIAS_GOOGLE, BACKEND_ALIAS_AMAZON
+from .caper_backend import BACKEND_ALIAS_SHERLOCK, BACKEND_ALIAS_SCG
+from .caper_uri import CaperURI, URI_LOCAL
+from .caper_args import DEFAULT_CROMWELL_JAR, DEFAULT_WOMTOOL_JAR
+
+
+DEFAULT_CROMWELL_JAR_INSTALL_DIR = '~/.caper/cromwell_jar'
+DEFAULT_WOMTOOL_JAR_INSTALL_DIR = '~/.caper/womtool_jar'
+DEFAULT_CONF_CONTENTS_LOCAL = """backend=local
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+DEFAULT_CONF_CONTENTS_SHERLOCK = """backend=slurm
+slurm-partition=
+
+# DO NOT use /tmp here
+# You can use $OAK or $SCRATCH storages here.
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+
+# IMPORTANT warning for Stanford Sherlock cluster
+# ====================================================================
+# DO NOT install any codes/executables
+# (java, conda, python, caper, pipeline's WDL, pipeline's Conda env, ...) on $SCRATCH or $OAK.
+# You will see Segmentation Fault errors.
+# Install all executables on $HOME or $PI_HOME instead.
+# It's STILL OKAY to read input data from and write outputs to $SCRATCH or $OAK.
+# ====================================================================
+"""
+DEFAULT_CONF_CONTENTS_SCG = """backend=slurm
+slurm-account=
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+DEFAULT_CONF_CONTENTS_SLURM = """backend=slurm
+
+# define one of the followings (or both) according to your
+# cluster's SLURM configuration.
+slurm-partition=
+slurm-account=
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+DEFAULT_CONF_CONTENTS_SGE = """backend=sge
+sge-pe=
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+DEFAULT_CONF_CONTENTS_PBS = """backend=pbs
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+DEFAULT_CONF_CONTENTS_AWS = """backend=aws
+aws-batch-arn=
+aws-region=
+out-s3-bucket=
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+DEFAULT_CONF_CONTENTS_GCP = """backend=gcp
+gcp-prj=
+out-gcs-bucket=
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+
+
+def install_cromwell_jar(uri):
+    """Download cromwell-X.jar
+    """
+    cu = CaperURI(uri)
+    if cu.uri_type == URI_LOCAL:
+        return cu.get_uri()
+    print('Downloading Cromwell JAR... {f}'.format(f=uri), file=sys.stderr)
+    path = os.path.join(
+        os.path.expanduser(DEFAULT_CROMWELL_JAR_INSTALL_DIR),
+        os.path.basename(uri))
+    return cu.copy(target_uri=path)
+
+
+def install_womtool_jar(uri):
+    """Download womtool-X.jar
+    """
+    cu = CaperURI(uri)
+    if cu.uri_type == URI_LOCAL:
+        return cu.get_uri()
+    print('Downloading Womtool JAR... {f}'.format(f=uri), file=sys.stderr)
+    path = os.path.join(
+        os.path.expanduser(DEFAULT_WOMTOOL_JAR_INSTALL_DIR),
+        os.path.basename(uri))
+    return cu.copy(target_uri=path)
+
+
+def init_caper_conf(args):
+    """Initialize conf file for a given platform.
+    Also, download/install Cromwell/Womtool JARs.
+    """
+    backend = args.get('platform')
+    assert(backend in BACKENDS_WITH_ALIASES)
+    if backend in (BACKEND_LOCAL, BACKEND_ALIAS_LOCAL):
+        contents = DEFAULT_CONF_CONTENTS_LOCAL
+    elif backend == BACKEND_ALIAS_SHERLOCK:
+        contents = DEFAULT_CONF_CONTENTS_SHERLOCK
+    elif backend == BACKEND_ALIAS_SCG:
+        contents = DEFAULT_CONF_CONTENTS_SCG
+    elif backend == BACKEND_SLURM:
+        contents = DEFAULT_CONF_CONTENTS_SLURM
+    elif backend == BACKEND_SGE:
+        contents = DEFAULT_CONF_CONTENTS_SGE
+    elif backend == BACKEND_PBS:
+        contents = DEFAULT_CONF_CONTENTS_PBS
+    elif backend in (BACKEND_GCP, BACKEND_ALIAS_GOOGLE):
+        contents = DEFAULT_CONF_CONTENTS_GCP
+    elif backend in (BACKEND_AWS, BACKEND_ALIAS_AMAZON):
+        contents = DEFAULT_CONF_CONTENTS_AWS
+    else:
+        raise Exception('Unsupported platform/backend/alias.')
+
+    conf_file = os.path.expanduser(args.get('conf'))
+    with open(conf_file, 'w') as fp:
+        fp.write(contents + '\n')
+        fp.write('{key}={val}\n'.format(
+            key='cromwell',
+            val=install_cromwell_jar(DEFAULT_CROMWELL_JAR)))
+        fp.write('{key}={val}\n'.format(
+            key='womtool',
+            val=install_womtool_jar(DEFAULT_WOMTOOL_JAR)))


### PR DESCRIPTION
Rebased it to get updates from other branches (PIP-925).

Created `caper_init.py` and moved all initialization stuffs to there.

`caper init` installs Cromwell and Womtool JARs. It downloads them and write their local paths explicitly in Caper's conf (default: `~/.caper/default.conf`) so that `caper run/server/submit` can work completely offline without sending requests everytime to git server hosting those JARs.

