### PR TITLE
Pip 930 parametrize call caching dup strat

### DIFF
--- a/caper/caper.py
+++ b/caper/caper.py
@@ -115,6 +115,7 @@ class Caper(object):
             self._tmp_dir = os.path.abspath(self._tmp_dir)
         self._gcp_prj = args.get('gcp_prj')
         self._gcp_zones = args.get('gcp_zones')
+        self._gcp_call_caching_dup_strat = args.get('gcp_call_caching_dup_strat')
         self._out_gcs_bucket = args.get('out_gcs_bucket')
         self._out_s3_bucket = args.get('out_s3_bucket')
         self._aws_batch_arn = args.get('aws_batch_arn')
@@ -910,6 +911,7 @@ class Caper(object):
                 CaperBackendGCP(
                     gcp_prj=self._gcp_prj,
                     out_gcs_bucket=self._out_gcs_bucket,
+                    call_caching_dup_strat=self._gcp_call_caching_dup_strat,
                     concurrent_job_limit=self._max_concurrent_tasks))
         # AWS
         if self._aws_batch_arn is not None and self._aws_region is not None \

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -242,7 +242,7 @@ def parse_caper_arguments():
         '--tmp-dir', help='Temporary directory for local backend')
 
     group_gc = parent_host.add_argument_group(
-        title='GC backend arguments')
+        title='GCP backend arguments')
     group_gc.add_argument('--gcp-prj', help='GC project')
     group_gc.add_argument('--gcp-zones', help='GCP zones (e.g. us-west1-b,'
                                               'us-central1-b)')
@@ -255,9 +255,9 @@ def parse_caper_arguments():
         help='Duplication strategy for call-cached outputs for GCP backend: '
              'copy: make a copy, reference: refer to old output in metadata.json.')
     group_gc.add_argument(
-        '--out-gcs-bucket', help='Output GCS bucket for GC backend')
+        '--out-gcs-bucket', help='Output GCS bucket for GCP backend')
     group_gc.add_argument(
-        '--tmp-gcs-bucket', help='Temporary GCS bucket for GC backend')
+        '--tmp-gcs-bucket', help='Temporary GCS bucket for GCP backend')
 
     group_aws = parent_host.add_argument_group(
         title='AWS backend arguments')

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -12,6 +12,7 @@ import os
 from distutils.util import strtobool
 from collections import OrderedDict
 from .caper_backend import CaperBackendDatabase
+from .caper_backend import CaperBackendGCP
 from .caper_backend import BACKENDS, BACKEND_LOCAL
 from .caper_backend import BACKEND_ALIAS_LOCAL
 from .caper_backend import BACKEND_ALIAS_SHERLOCK, BACKEND_ALIAS_SCG
@@ -47,6 +48,8 @@ DEFAULT_DEEPCOPY_EXT = 'json,tsv'
 DEFAULT_SERVER_HEARTBEAT_FILE = '~/.caper/default_server_heartbeat'
 DEFAULT_SERVER_HEARTBEAT_TIMEOUT_MS = 120000
 DEFAULT_CONF_CONTENTS = '\n\n'
+DEFAULT_GCP_CALL_CACHING_DUP_STRAT = CaperBackendGCP.CALL_CACHING_DUP_STRAT_REFERENCE
+
 DYN_FLAGS = ['--singularity', '--docker']
 INVALID_EXT_FOR_DYN_FLAG = '.wdl'
 
@@ -243,6 +246,14 @@ def parse_caper_arguments():
     group_gc.add_argument('--gcp-prj', help='GC project')
     group_gc.add_argument('--gcp-zones', help='GCP zones (e.g. us-west1-b,'
                                               'us-central1-b)')
+    group_gc.add_argument(
+        '--gcp-call-caching-dup-strat', default=DEFAULT_GCP_CALL_CACHING_DUP_STRAT,
+        choices=[
+            CaperBackendGCP.CALL_CACHING_DUP_STRAT_REFERENCE,
+            CaperBackendGCP.CALL_CACHING_DUP_STRAT_COPY
+        ],
+        help='Duplication strategy for call-cached outputs for GCP backend: '
+             'copy: make a copy, reference: refer to old output in metadata.json.')
     group_gc.add_argument(
         '--out-gcs-bucket', help='Output GCS bucket for GC backend')
     group_gc.add_argument(

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -180,6 +180,9 @@ class CaperBackendDatabase(dict):
 class CaperBackendGCP(dict):
     """Google Cloud backend
     """
+    CALL_CACHING_DUP_STRAT_REFERENCE = 'reference'
+    CALL_CACHING_DUP_STRAT_COPY = 'copy'
+
     TEMPLATE = {
         "backend": {
             "providers": {
@@ -202,7 +205,10 @@ class CaperBackendGCP(dict):
                         },
                         "filesystems": {
                             "gcs": {
-                                "auth": "application-default"
+                                "auth": "application-default",
+                                "caching": {
+                                    "duplication-strategy": CALL_CACHING_DUP_STRAT_REFERENCE
+                                }
                             }
                         }
                     }
@@ -220,7 +226,8 @@ class CaperBackendGCP(dict):
         }
     }
 
-    def __init__(self, gcp_prj, out_gcs_bucket, concurrent_job_limit=None):
+    def __init__(self, gcp_prj, out_gcs_bucket, concurrent_job_limit=None,
+                 call_caching_dup_strat=None):
         super(CaperBackendGCP, self).__init__(
             CaperBackendGCP.TEMPLATE)
         config = self['backend']['providers'][BACKEND_GCP]['config']
@@ -230,6 +237,11 @@ class CaperBackendGCP(dict):
 
         if concurrent_job_limit is not None:
             config['concurrent-job-limit'] = concurrent_job_limit
+        if call_caching_dup_strat is not None:
+            assert call_caching_dup_strat in (
+                CaperBackendGCP.CALL_CACHING_DUP_STRAT_REFERENCE,
+                CaperBackendGCP.CALL_CACHING_DUP_STRAT_COPY)
+            config['filesystems']['gcs']['caching']['duplication-strategy'] = call_caching_dup_strat
 
 
 class CaperBackendAWS(dict):

--- a/caper/caper_init.py
+++ b/caper/caper_init.py
@@ -107,6 +107,11 @@ DEFAULT_CONF_CONTENTS_GCP = """backend=gcp
 gcp-prj=
 out-gcs-bucket=
 
+# call-cached outputs will be duplicated by making a copy or reference
+#  reference: refer to old output file in metadata.json file.
+#  copy: make a copy
+gcp-call-caching-dup-strat=
+
 # DO NOT use /tmp here
 # Caper stores all important temp files and cached big data files here
 # If not defined, Caper will make .caper_tmp/ on your local output directory


### PR DESCRIPTION
Cromwell changed its default duplication strategy on Google Cloud Storage (GCS: `gs://`) from "reference" to "copy" somewhere in their 4x versions.

In most cases, users blindly re-run failed workflows believing that call-cached outputs will not be copied on the new output bucket directory. This can lead to filling up their bucket storage with unnecessary files.

This PR changes the default strategy to "reference" and users can specify it in conf file or in cmd line args: `--gcp-call-caching-dup-strat`.
