### PR TITLE
Pip 881 soft glob

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -239,6 +239,7 @@ We highly recommend to use a default configuration file described in the section
 	max-concurrent-workflows|--max-concurrent-workflows|40|Maximum number of concurrent workflows
 	max-retries|--max-retries|1|Maximum number of retries for failing tasks
 	disable-call-caching|--disable-call-caching| |Disable Cromwell's call-caching (re-using outputs)
+	soft-glob-output|--soft-glob-output||Use soft-linking for globbing outputs for a filesystem that does not allow hard-linking: e.g. beeGFS.
 	backend-file|--backend-file| |Custom Cromwell backend conf file. This will override Caper's built-in backends
 
 * Troubleshoot parameters for `caper troubleshoot` subcommand.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**IMPORATNT**: A new flag `--soft-glob-output` is added to use soft-linking for globbing outputs. Use it for `caper server/run` (not for `caper submit`) on a filesystem that does not allow hard-linking: e.g. beeGFS.
+
 **IMPORATNT**: Caper defaults back to **NOT** use a file-based metadata DB, which means no call-caching (re-using outputs from previous workflows) by default.
 
 **IMPORATNT**: Even if you still want to use a file-based DB (`--db file` and `--file-db [DB_PATH]`), metadata DB generated from Caper<0.6 (with Cromwell-42) is not compatible with metadata DB generated from Caper>=0.6 (with Cromwell-47). Refer to [this doc](https://github.com/broadinstitute/cromwell/releases/tag/43) for such migration.

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -130,6 +130,7 @@ class Caper(object):
         self._pbs_extra_param = args.get('pbs_extra_param')
 
         self._backend_file = args.get('backend_file')
+        self._soft_glob_output = args.get('soft_glob_output')
         self._wdl = args.get('wdl')
         self._inputs = args.get('inputs')
         self._cromwell = args.get('cromwell')
@@ -903,7 +904,8 @@ class Caper(object):
             backend_dict,
             CaperBackendLocal(
                 out_dir=self._out_dir,
-                concurrent_job_limit=self._max_concurrent_tasks))
+                concurrent_job_limit=self._max_concurrent_tasks,
+                soft_glob_output=self._soft_glob_output))
         # GC
         if self._gcp_prj is not None and self._out_gcs_bucket is not None:
             merge_dict(
@@ -931,7 +933,8 @@ class Caper(object):
                 partition=self._slurm_partition,
                 account=self._slurm_account,
                 extra_param=self._slurm_extra_param,
-                concurrent_job_limit=self._max_concurrent_tasks))
+                concurrent_job_limit=self._max_concurrent_tasks,
+                soft_glob_output=self._soft_glob_output))
         # SGE
         merge_dict(
             backend_dict,
@@ -940,7 +943,8 @@ class Caper(object):
                 pe=self._sge_pe,
                 queue=self._sge_queue,
                 extra_param=self._sge_extra_param,
-                concurrent_job_limit=self._max_concurrent_tasks))
+                concurrent_job_limit=self._max_concurrent_tasks,
+                soft_glob_output=self._soft_glob_output))
 
         # PBS
         merge_dict(
@@ -949,7 +953,8 @@ class Caper(object):
                 out_dir=self._out_dir,
                 queue=self._pbs_queue,
                 extra_param=self._pbs_extra_param,
-                concurrent_job_limit=self._max_concurrent_tasks))
+                concurrent_job_limit=self._max_concurrent_tasks,
+                soft_glob_output=self._soft_glob_output))
 
         # Database
         merge_dict(

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -40,6 +40,7 @@ from .caper_backend import BACKEND_GCP, BACKEND_AWS, BACKEND_LOCAL, \
     CaperBackendCommon, CaperBackendDatabase, CaperBackendGCP, \
     CaperBackendAWS, CaperBackendLocal, CaperBackendSLURM, \
     CaperBackendSGE, CaperBackendPBS
+from .caper_backend import CaperBackendBase, CaperBackendBaseLocal
 
 
 class Caper(object):
@@ -899,13 +900,21 @@ class Caper(object):
                 disable_call_caching=self._disable_call_caching,
                 max_concurrent_workflows=self._max_concurrent_workflows))
 
+        # common settings for all backends
+        if self._max_concurrent_tasks is not None:
+            CaperBackendBase.CONCURRENT_JOB_LIMIT = self._max_concurrent_tasks
+
+        # common settings for local-based backends
+        if self._soft_glob_output is not None:
+            CaperBackendBaseLocal.USE_SOFT_GLOB_OUTPUT = self._soft_glob_output
+        if self._out_dir is not None:
+            CaperBackendBaseLocal.OUT_DIR = self._out_dir
+
         # local backend
         merge_dict(
             backend_dict,
-            CaperBackendLocal(
-                out_dir=self._out_dir,
-                concurrent_job_limit=self._max_concurrent_tasks,
-                soft_glob_output=self._soft_glob_output))
+            CaperBackendLocal())
+
         # GC
         if self._gcp_prj is not None and self._out_gcs_bucket is not None:
             merge_dict(
@@ -913,8 +922,8 @@ class Caper(object):
                 CaperBackendGCP(
                     gcp_prj=self._gcp_prj,
                     out_gcs_bucket=self._out_gcs_bucket,
-                    call_caching_dup_strat=self._gcp_call_caching_dup_strat,
-                    concurrent_job_limit=self._max_concurrent_tasks))
+                    call_caching_dup_strat=self._gcp_call_caching_dup_strat))
+
         # AWS
         if self._aws_batch_arn is not None and self._aws_region is not None \
                 and self._out_s3_bucket is not None:
@@ -923,38 +932,30 @@ class Caper(object):
                 CaperBackendAWS(
                     aws_batch_arn=self._aws_batch_arn,
                     aws_region=self._aws_region,
-                    out_s3_bucket=self._out_s3_bucket,
-                    concurrent_job_limit=self._max_concurrent_tasks))
+                    out_s3_bucket=self._out_s3_bucket))
+
         # SLURM
         merge_dict(
             backend_dict,
             CaperBackendSLURM(
-                out_dir=self._out_dir,
                 partition=self._slurm_partition,
                 account=self._slurm_account,
-                extra_param=self._slurm_extra_param,
-                concurrent_job_limit=self._max_concurrent_tasks,
-                soft_glob_output=self._soft_glob_output))
+                extra_param=self._slurm_extra_param))
+
         # SGE
         merge_dict(
             backend_dict,
             CaperBackendSGE(
-                out_dir=self._out_dir,
                 pe=self._sge_pe,
                 queue=self._sge_queue,
-                extra_param=self._sge_extra_param,
-                concurrent_job_limit=self._max_concurrent_tasks,
-                soft_glob_output=self._soft_glob_output))
+                extra_param=self._sge_extra_param))
 
         # PBS
         merge_dict(
             backend_dict,
             CaperBackendPBS(
-                out_dir=self._out_dir,
                 queue=self._pbs_queue,
-                extra_param=self._pbs_extra_param,
-                concurrent_job_limit=self._max_concurrent_tasks,
-                soft_glob_output=self._soft_glob_output))
+                extra_param=self._pbs_extra_param))
 
         # Database
         merge_dict(

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -233,6 +233,14 @@ def parse_caper_arguments():
     group_cromwell.add_argument(
         '--backend-file',
         help='Custom Cromwell backend configuration file to override all')
+    group_cromwell.add_argument(
+        '--soft-glob-output', action='store_true',
+        help='Use soft-linking when globbing outputs for a filesystem that '
+             'does not allow hard-linking. e.g. beeGFS. '
+             'This flag does not work with backends based on a Docker container. '
+             'i.e. gcp and aws. Also, '
+             'it does not work with local backends (local/slurm/sge/pbs) '
+             'with --docker. However, it works fine with --singularity.'
 
     group_local = parent_host.add_argument_group(
         title='local backend arguments')
@@ -531,6 +539,7 @@ def parse_caper_arguments():
         'dry_run',
         'no_server_heartbeat',
         'disable_call_caching',
+        'soft_glob_output',
         'use_gsutil_over_aws_s3',
         'hold',
         'no_deepcopy',

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -240,7 +240,7 @@ def parse_caper_arguments():
              'This flag does not work with backends based on a Docker container. '
              'i.e. gcp and aws. Also, '
              'it does not work with local backends (local/slurm/sge/pbs) '
-             'with --docker. However, it works fine with --singularity.'
+             'with --docker. However, it works fine with --singularity.')
 
     group_local = parent_host.add_argument_group(
         title='local backend arguments')

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Caper backend
 """
+from collections import UserDict
+
 
 BACKEND_GCP = 'gcp'
 BACKEND_AWS = 'aws'
@@ -39,7 +41,7 @@ def get_backend(backend):
     return backend
 
 
-class CaperBackendCommon(dict):
+class CaperBackendCommon(UserDict):
     """Common stanzas for all Caper backends
     """
     TEMPLATE = {
@@ -87,7 +89,7 @@ class CaperBackendCommon(dict):
                 max_concurrent_workflows
 
 
-class CaperBackendDatabase(dict):
+class CaperBackendDatabase(UserDict):
     """Common stanzas for database
     """
     DB_TYPE_IN_MEMORY = 'in-memory'
@@ -178,7 +180,7 @@ class CaperBackendDatabase(dict):
             self['database']['db']['connectionTimeout'] = db_timeout
 
 
-class CaperBackendGCP(dict):
+class CaperBackendGCP(UserDict):
     """Google Cloud backend
     """
     CALL_CACHING_DUP_STRAT_REFERENCE = 'reference'
@@ -245,7 +247,7 @@ class CaperBackendGCP(dict):
             config['filesystems']['gcs']['caching']['duplication-strategy'] = call_caching_dup_strat
 
 
-class CaperBackendAWS(dict):
+class CaperBackendAWS(UserDict):
     """AWS backend
     """
     TEMPLATE = {
@@ -305,7 +307,7 @@ class CaperBackendAWS(dict):
             config['concurrent-job-limit'] = concurrent_job_limit
 
 
-class CaperBackendLocal(dict):
+class CaperBackendLocal(UserDict):
     """Local backend
     """
     RUNTIME_ATTRIBUTES = """
@@ -372,7 +374,7 @@ class CaperBackendLocal(dict):
             config['glob-link-command'] = SOFT_GLOB_OUTPUT_CMD
 
 
-class CaperBackendSLURM(dict):
+class CaperBackendSLURM(UserDict):
     """SLURM backend
     """
     RUNTIME_ATTRIBUTES = """
@@ -468,7 +470,7 @@ class CaperBackendSLURM(dict):
             config['glob-link-command'] = SOFT_GLOB_OUTPUT_CMD
 
 
-class CaperBackendSGE(dict):
+class CaperBackendSGE(UserDict):
     """SGE backend
     """
     RUNTIME_ATTRIBUTES = """
@@ -564,7 +566,7 @@ ${true=")m" false="" defined(memory_mb)} \
             config['glob-link-command'] = SOFT_GLOB_OUTPUT_CMD
 
 
-class CaperBackendPBS(dict):
+class CaperBackendPBS(UserDict):
     """PBS backend
     """
     RUNTIME_ATTRIBUTES = """

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -197,10 +197,10 @@ class CaperBackendBase(UserDict):
         }
     }
 
-    def __init__(self, d=None, backend_name=None):
+    def __init__(self, dict_to_override_self=None, backend_name=None):
         """
         Args:
-            d: dict to override self
+            dict_to_override_self: dict to override self
             backend_name: backend name
         """
         if backend_name is None:
@@ -215,8 +215,8 @@ class CaperBackendBase(UserDict):
             raise ValueError('You must define CaperBackendBase.CONCURRENT_JOB_LIMIT.')
         config['concurrent-job-limit'] = CaperBackendBase.CONCURRENT_JOB_LIMIT
 
-        if d is not None:
-            merge_dict(self, deepcopy(d))
+        if dict_to_override_self is not None:
+            merge_dict(self, deepcopy(dict_to_override_self))
 
     @property
     def backend_name(self):
@@ -247,7 +247,7 @@ class CaperBackendBaseLocal(CaperBackendBase):
             "root": None
         }
     }
-    def __init__(self, d=None, backend_name=None):
+    def __init__(self, dict_to_override_self=None, backend_name=None):
         super().__init__(backend_name=backend_name)
 
         merge_dict(
@@ -264,8 +264,8 @@ class CaperBackendBaseLocal(CaperBackendBase):
             raise ValueError('You must define CaperBackendBase.OUT_DIR.')
         config['root'] = CaperBackendBaseLocal.OUT_DIR
 
-        if d is not None:
-            merge_dict(self, deepcopy(d))
+        if dict_to_override_self is not None:
+            merge_dict(self, deepcopy(dict_to_override_self))
 
 
 class CaperBackendGCP(CaperBackendBase):

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -196,14 +196,19 @@ class CaperBackendBase(UserDict):
             "concurrent-job-limit": None
         }
     }
-    def __init__(self, backend_name, d=None):
+
+    def __init__(self, d=None, backend_name=None):
         """
         Args:
+            d: dict to override self
             backend_name: backend name
-            d: dict to override this class on
         """
-        super().__init__(deepcopy(CaperBackendBase.TEMPLATE))
+        if backend_name is None:
+            raise ValueError('backend_name must be provided.')
         self._backend_name = backend_name
+
+        super().__init__(deepcopy(CaperBackendBase.TEMPLATE))
+
         config = self.get_backend_config()
 
         if CaperBackendBase.CONCURRENT_JOB_LIMIT is None:
@@ -212,6 +217,10 @@ class CaperBackendBase(UserDict):
 
         if d is not None:
             merge_dict(self, deepcopy(d))
+
+    @property
+    def backend_name(self):
+        return self._backend_name
 
     def get_backend(self):
         if self._backend_name not in self['backend']['providers']:
@@ -238,7 +247,7 @@ class CaperBackendBaseLocal(CaperBackendBase):
             "root": None
         }
     }
-    def __init__(self, backend_name, d=None):
+    def __init__(self, d=None, backend_name=None):
         super().__init__(backend_name=backend_name)
 
         merge_dict(
@@ -309,8 +318,8 @@ class CaperBackendGCP(CaperBackendBase):
     def __init__(self, gcp_prj, out_gcs_bucket,
                  call_caching_dup_strat=None):
         super().__init__(
-            backend_name=BACKEND_GCP,
-            d=CaperBackendGCP.TEMPLATE)
+            CaperBackendGCP.TEMPLATE,
+            backend_name=BACKEND_GCP)
         config = self.get_backend_config()
 
         config['project'] = gcp_prj
@@ -378,8 +387,8 @@ class CaperBackendAWS(CaperBackendBase):
 
     def __init__(self, aws_batch_arn, aws_region, out_s3_bucket):
         super().__init__(
-            backend_name=BACKEND_AWS,
-            d=CaperBackendAWS.TEMPLATE)
+            CaperBackendAWS.TEMPLATE,
+            backend_name=BACKEND_AWS)
         self[BACKEND_AWS]['region'] = aws_region
         config = self.get_backend_config()
         config['default-runtime-attributes']['queueArn'] = aws_batch_arn
@@ -439,8 +448,8 @@ class CaperBackendLocal(CaperBackendBaseLocal):
 
     def __init__(self):
         super().__init__(
-            backend_name=BACKEND_LOCAL,
-            d=CaperBackendLocal.TEMPLATE)
+            CaperBackendLocal.TEMPLATE,
+            backend_name=BACKEND_LOCAL)
 
 
 class CaperBackendSLURM(CaperBackendBaseLocal):
@@ -517,8 +526,8 @@ class CaperBackendSLURM(CaperBackendBaseLocal):
 
     def __init__(self, partition=None, account=None, extra_param=None):
         super().__init__(
-            backend_name=BACKEND_SLURM,
-            d=CaperBackendSLURM.TEMPLATE)
+            CaperBackendSLURM.TEMPLATE,
+            backend_name=BACKEND_SLURM)
         config = self.get_backend_config()
 
         if partition is not None and partition != '':
@@ -603,8 +612,8 @@ ${true=")m" false="" defined(memory_mb)} \
 
     def __init__(self, pe=None, queue=None, extra_param=None):
         super().__init__(
-            backend_name=BACKEND_SGE,
-            d=CaperBackendSGE.TEMPLATE)
+            CaperBackendSGE.TEMPLATE,
+            backend_name=BACKEND_SGE)
         config = self.get_backend_config()
 
         if pe is not None and pe != '':
@@ -676,8 +685,8 @@ ${true=":0:0" false="" defined(time)} \
 
     def __init__(self, queue=None, extra_param=None):
         super().__init__(
-            backend_name=BACKEND_PBS,
-            d=CaperBackendPBS.TEMPLATE)
+            CaperBackendPBS.TEMPLATE,
+            backend_name=BACKEND_PBS)
         config = self.get_backend_config()
 
         if queue is not None and queue != '':

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -21,6 +21,7 @@ BACKEND_ALIASES = [BACKEND_ALIAS_LOCAL, BACKEND_ALIAS_GOOGLE, BACKEND_ALIAS_AMAZ
 
 BACKENDS_WITH_ALIASES = BACKENDS + BACKEND_ALIASES
 
+SOFT_GLOB_OUTPUT_CMD = 'ln -sL GLOB_PATTERN GLOB_DIRECTORY 2> /dev/null'
 
 def get_backend(backend):
     if backend == BACKEND_ALIAS_GOOGLE:
@@ -358,7 +359,8 @@ class CaperBackendLocal(dict):
         }
     }
 
-    def __init__(self, out_dir, concurrent_job_limit=None):
+    def __init__(self, out_dir, concurrent_job_limit=None,
+                 soft_glob_output=False):
         super(CaperBackendLocal, self).__init__(
             CaperBackendLocal.TEMPLATE)
         config = self['backend']['providers'][BACKEND_LOCAL]['config']
@@ -366,6 +368,8 @@ class CaperBackendLocal(dict):
 
         if concurrent_job_limit is not None:
             config['concurrent-job-limit'] = concurrent_job_limit
+        if soft_glob_output:
+            config['glob-link-command'] = SOFT_GLOB_OUTPUT_CMD
 
 
 class CaperBackendSLURM(dict):
@@ -445,7 +449,7 @@ class CaperBackendSLURM(dict):
     }
 
     def __init__(self, out_dir, partition=None, account=None, extra_param=None,
-                 concurrent_job_limit=None):
+                 concurrent_job_limit=None, soft_glob_output=False):
         super(CaperBackendSLURM, self).__init__(
             CaperBackendSLURM.TEMPLATE)
         config = self['backend']['providers'][BACKEND_SLURM]['config']
@@ -460,6 +464,8 @@ class CaperBackendSLURM(dict):
             config[key]['slurm_extra_param'] = extra_param
         if concurrent_job_limit is not None:
             config['concurrent-job-limit'] = concurrent_job_limit
+        if soft_glob_output:
+            config['glob-link-command'] = SOFT_GLOB_OUTPUT_CMD
 
 
 class CaperBackendSGE(dict):
@@ -539,7 +545,7 @@ ${true=")m" false="" defined(memory_mb)} \
     }
 
     def __init__(self, out_dir, pe=None, queue=None, extra_param=None,
-                 concurrent_job_limit=None):
+                 concurrent_job_limit=None, soft_glob_output=False):
         super(CaperBackendSGE, self).__init__(
             CaperBackendSGE.TEMPLATE)
         config = self['backend']['providers'][BACKEND_SGE]['config']
@@ -554,6 +560,8 @@ ${true=")m" false="" defined(memory_mb)} \
             config[key]['sge_extra_param'] = extra_param
         if concurrent_job_limit is not None:
             config['concurrent-job-limit'] = concurrent_job_limit
+        if soft_glob_output:
+            config['glob-link-command'] = SOFT_GLOB_OUTPUT_CMD
 
 
 class CaperBackendPBS(dict):
@@ -619,7 +627,7 @@ ${true=":0:0" false="" defined(time)} \
     }
 
     def __init__(self, out_dir, queue=None, extra_param=None,
-                 concurrent_job_limit=None):
+                 concurrent_job_limit=None, soft_glob_output=False):
         super(CaperBackendPBS, self).__init__(
             CaperBackendPBS.TEMPLATE)
         config = self['backend']['providers'][BACKEND_PBS]['config']
@@ -632,6 +640,8 @@ ${true=":0:0" false="" defined(time)} \
             config[key]['pbs_extra_param'] = extra_param
         if concurrent_job_limit is not None:
             config['concurrent-job-limit'] = concurrent_job_limit
+        if soft_glob_output:
+            config['glob-link-command'] = SOFT_GLOB_OUTPUT_CMD
 
 
 def main():

--- a/caper/caper_check.py
+++ b/caper/caper_check.py
@@ -122,4 +122,10 @@ def check_caper_conf(args_d):
                 '--out-s3-bucket (s3:// output bucket path) '
                 'is required for backend aws.')
 
+    if args_d.get('soft_glob_output') and args_d.get('use_docker'):
+        raise ValueError(
+                '--soft-glob-output and --docker are mutually exclusive. '
+                'Delocalization from docker container will fail '
+                'for soft-linked globbed outputs.')
+
     return args_d


### PR DESCRIPTION
Some file system (e.g. beeGFS) does not allow hard-linking. We can configure Cromwell to use soft-linking for both localizing inputs and globbing outputs.

For localizing inputs, Cromwell first tries with hard-linking and if it fails then it falls back to soft-linking. So we don't need any extra configuration for this in a backend file.

For globbing outputs, `--soft-glob-output` is added. This parameter is for local-based backends only. e.g. `local`, `sge`, `slurm` and `pbs`.
