### PR TITLE
v0.7.0

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -41,6 +41,19 @@ list     | WF_ID or STR_LABEL |List submitted workflows on a Cromwell server
 metadata | WF_ID or STR_LABEL |Retrieve metadata JSONs for workflows
 debug, troubleshoot | WF_ID, STR_LABEL or<br>METADATA_JSON_FILE |Analyze reason for errors
 
+* `init`: To initialize Caper on a given platform. This command also downloads Cromwell/Womtool JARs so that Caper can work completely offline with local data files.
+
+	**Platform**|**Description**
+	:--------|:-----
+	sherlock | Stanford Sherlock cluster (SLURM)
+	scg | Stanford SCG cluster (SLURM)
+	gcp | Google Cloud Platform
+	aws | Amazon Web Service
+	local | General local computer
+	sge | HPC with Sun GridEngine cluster engine
+	pbs | HPC with PBS cluster engine
+	slurm | HPC with SLURM cluster engine
+
 * `run`: To run a single workflow. A string label `-s` is optional and useful for other subcommands to indentify a workflow.
 
 	```bash
@@ -217,6 +230,10 @@ We highly recommend to use a default configuration file described in the section
 	:-----|:-----|:-----|:-----
 	ip|--ip|localhost|Cromwell server IP address or hostname
 	port|--port|8000|Cromwell server port
+	no-server-heartbeat|--no-server-heartbeat||Flag to disable server heartbeat file.
+	server-heartbeat-file|--server-heartbeat-file|`~/.caper/default_server_heartbeat`|Heartbeat file for Caper clients to get IP and port of a server.
+	server-heartbeat-timeout|--server-heartbeat-timeout|120000|Timeout for a heartbeat file in Milliseconds.
+
 	cromwell|--cromwell|[cromwell-40.jar](https://github.com/broadinstitute/cromwell/releases/download/40/cromwell-40.jar)|Path or URL for Cromwell JAR file
 	max-concurrent-tasks|--max-concurrent-tasks|1000|Maximum number of concurrent tasks
 	max-concurrent-workflows|--max-concurrent-workflows|40|Maximum number of concurrent workflows

--- a/DETAILS.md
+++ b/DETAILS.md
@@ -239,6 +239,7 @@ We highly recommend to use a default configuration file described in the section
 	max-concurrent-workflows|--max-concurrent-workflows|40|Maximum number of concurrent workflows
 	max-retries|--max-retries|1|Maximum number of retries for failing tasks
 	disable-call-caching|--disable-call-caching| |Disable Cromwell's call-caching (re-using outputs)
+	soft-glob-output|--soft-glob-output||Use soft-linking for globbing outputs for a filesystem that does not allow hard-linking: e.g. beeGFS.
 	backend-file|--backend-file| |Custom Cromwell backend conf file. This will override Caper's built-in backends
 
 * Troubleshoot parameters for `caper troubleshoot` subcommand.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,41 @@ $ cd [OUTPUT_DIR]  # make a separate directory for each workflow
 $ caper run [WDL] -i [INPUT_JSON]
 ```
 
+
+## Caper server heartbeat (running multiple servers)
+
+Caper server writes a heartbeat file (specified by `--server-heartbeat-file`) on every 120 seconds (controlled by `--server-heartbeat-timeout`). This file will contain an IP(hostname)/PORT pair of the running `caper server`.
+
+Example heartbeat file:
+```bash
+$ cat ~/.caper/default_server_heartbeat
+kadru.stanford.edu:8000
+```
+
+This heartbeat file is useful when users don't want to find IP(hostname)/PORT of a running `caper server` especially when they `qsub`bed or `sbatch`ed `caper server` on their clusters. For such cases, IP (hostname of node/instance) of the server is later determined after the cluster engine starts the submitted `caper server` job and it's inconvenient for the users to find the IP (hostname) of the running server manually with `qstat` or `squeue` and add it back to Caper's configuration file `~/.caper/default.conf`.
+
+Therefore, Caper defaults to use this heartbeat file (can be disabled by a flag `--no-server-heartbeat`). So if client-side caper functions like `caper list` and `caper metadata` finds this heartbeat file and automatically parse it to get an IP/PORT pair.
+
+However, there can be a conflict if users want to run multiple `caper server`s on the same machine (or multiple machines sharing the same caper configuration directory `~/.caper/` and hence the same default heartbeat file). For such cases, users can disable this heartbeat feature by adding the following line to their configuration file: e.g. `~/.caper/default.conf`.
+```bash
+no-server-heartbeat=True
+```
+
+Then start multiple servers with different port and DB (for example of MySQL). Users should make sure that each server uses a different DB (file or MySQL server port, whatever...) since there is no point of using multiple Caper servers with the same DB. For example of MySQL, users should not forget to spin up multiple MySQL servers with different ports.
+
+```bash
+$ caper server --port 8000 --mysql-db-port 3306 ... &
+$ caper server --port 8001 --mysql-db-port 3307 ... &
+$ caper server --port 8002 --mysql-db-port 3308 ... &
+```
+
+Send queries to a specific server.
+```bash
+$ caper list --port 8000
+$ caper list --port 8001
+$ caper list --port 8002
+```
+
 ## Metadata database
 
 If you are not interested in resuming failed workflows skip this section.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**IMPORATNT**: A new flag `--soft-glob-output` is added to use soft-linking for globbing outputs. Use it for `caper server/run` (not for `caper submit`) on a filesystem that does not allow hard-linking: e.g. beeGFS.
+
 **IMPORATNT**: Caper defaults back to **NOT** use a file-based metadata DB, which means no call-caching (re-using outputs from previous workflows) by default.
 
 **IMPORATNT**: Even if you still want to use a file-based DB (`--db file` and `--file-db [DB_PATH]`), metadata DB generated from Caper<0.6 (with Cromwell-42) is not compatible with metadata DB generated from Caper>=0.6 (with Cromwell-47). Refer to [this doc](https://github.com/broadinstitute/cromwell/releases/tag/43) for such migration.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and 
 	export PATH=$PATH:~/.local/bin
 	```
 
-5) Choose a platform from the following table and initialize Caper. This will create a default Caper configuration file `~/.caper/default.conf`, which have only required parameters for each platform. There are special platforms for Stanford Sherlock/SCG users.
+5) Choose a platform from the following table and initialize Caper. This will create a default Caper configuration file `~/.caper/default.conf`, which have only required parameters for each platform. There are special platforms for Stanford Sherlock/SCG users. This will also install Cromwell/Womtool JARs on `~/.caper`. Downloading those files can take up to 10 minutes. Once they are installed, Caper can completely work offline with local data files.
+
 	```bash
 	$ caper init [PLATFORM]
 	```

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -115,6 +115,7 @@ class Caper(object):
             self._tmp_dir = os.path.abspath(self._tmp_dir)
         self._gcp_prj = args.get('gcp_prj')
         self._gcp_zones = args.get('gcp_zones')
+        self._gcp_call_caching_dup_strat = args.get('gcp_call_caching_dup_strat')
         self._out_gcs_bucket = args.get('out_gcs_bucket')
         self._out_s3_bucket = args.get('out_s3_bucket')
         self._aws_batch_arn = args.get('aws_batch_arn')
@@ -910,6 +911,7 @@ class Caper(object):
                 CaperBackendGCP(
                     gcp_prj=self._gcp_prj,
                     out_gcs_bucket=self._out_gcs_bucket,
+                    call_caching_dup_strat=self._gcp_call_caching_dup_strat,
                     concurrent_job_limit=self._max_concurrent_tasks))
         # AWS
         if self._aws_batch_arn is not None and self._aws_region is not None \

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -490,14 +490,16 @@ class Caper(object):
                 if f == 'workflow_id':
                     row.append(str(workflow_id))
                 elif f == 'str_label':
-                    lbl = self._cromwell_rest_api.get_label(
-                        workflow_id,
-                        Caper.KEY_CAPER_STR_LABEL)
+                    if 'labels' in w and Caper.KEY_CAPER_STR_LABEL in w['labels']:
+                        lbl = w['labels'][Caper.KEY_CAPER_STR_LABEL]
+                    else:
+                        lbl = None
                     row.append(str(lbl))
                 elif f == 'user':
-                    lbl = self._cromwell_rest_api.get_label(
-                        workflow_id,
-                        Caper.KEY_CAPER_USER)
+                    if 'labels' in w and Caper.KEY_CAPER_USER in w['labels']:
+                        lbl = w['labels'][Caper.KEY_CAPER_USER]
+                    else:
+                        lbl = None
                     row.append(str(lbl))
                 else:
                     row.append(str(w[f] if f in w else None))

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -29,7 +29,9 @@ from subprocess import Popen, check_call, PIPE, CalledProcessError
 from datetime import datetime
 
 from .dict_tool import merge_dict
-from .caper_args import parse_caper_arguments, install_cromwell_jar, install_womtool_jar
+from .caper_args import parse_caper_arguments
+from .caper_init import init_caper_conf, install_cromwell_jar, install_womtool_jar
+
 from .caper_check import check_caper_conf
 from .cromwell_rest_api import CromwellRestAPI
 from .caper_uri import URI_S3, URI_GCS, URI_LOCAL, \
@@ -559,7 +561,6 @@ class Caper(object):
                 except:
                     print('[Caper] Warning: failed to read server_heartbeat_file',
                           self._server_hearbeat_file)
-        print(self._no_server_hearbeat, self._server_hearbeat_file, ip, port)
         return ip, port
 
     def __write_heartbeat_file(self):
@@ -1231,6 +1232,10 @@ def main():
     # parse arguments
     #   note that args is a dict
     args = parse_caper_arguments()
+    action = args['action']
+    if action == 'init':
+        init_caper_conf(args)
+        sys.exit(0)
     args = check_caper_conf(args)
 
     # init caper uri to transfer files across various storages
@@ -1245,10 +1250,9 @@ def main():
         use_gsutil_over_aws_s3=args.get('use_gsutil_over_aws_s3'),
         verbose=True)
 
-    # init caper: taking all args at init step
+    # initialize caper: taking all args at init step
     c = Caper(args)
 
-    action = args['action']
     if action == 'run':
         c.run()
     elif action == 'server':

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -88,6 +88,7 @@ class Caper(object):
             action=args.get('action'),
             ip=args.get('ip'),
             port=args.get('port'),
+            no_server_hearbeat=args.get('no_server_heartbeat'),
             server_hearbeat_file=args.get('server_heartbeat_file'),
             server_hearbeat_timeout=args.get('server_heartbeat_timeout'))
 
@@ -531,8 +532,10 @@ class Caper(object):
             Caper.__troubleshoot(metadata, self._show_completed_task)
 
     def __init_cromwell_rest_api(self, action, ip, port,
+                                 no_server_hearbeat,
                                  server_hearbeat_file,
                                  server_hearbeat_timeout):
+        self._no_server_hearbeat = no_server_hearbeat
         self._server_hearbeat_file = server_hearbeat_file
         self._ip, self._port = \
             self.__read_heartbeat_file(action, ip, port, server_hearbeat_timeout)
@@ -541,7 +544,7 @@ class Caper(object):
             ip=self._ip, port=self._port, verbose=False)
 
     def __read_heartbeat_file(self, action, ip, port, server_hearbeat_timeout):
-        if self._server_hearbeat_file is not None:
+        if not self._no_server_hearbeat and self._server_hearbeat_file is not None:
             self._server_hearbeat_file = os.path.expanduser(
                 self._server_hearbeat_file)
             if action != 'server':
@@ -556,10 +559,11 @@ class Caper(object):
                 except:
                     print('[Caper] Warning: failed to read server_heartbeat_file',
                           self._server_hearbeat_file)
+        print(self._no_server_hearbeat, self._server_hearbeat_file, ip, port)
         return ip, port
 
     def __write_heartbeat_file(self):
-        if self._server_hearbeat_file is not None:
+        if not self._no_server_hearbeat and self._server_hearbeat_file is not None:
             while True:
                 try:
                     print('[Caper] Writing heartbeat',

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -553,6 +553,9 @@ def parse_caper_arguments():
         '--ip', default=DEFAULT_IP,
         help='IP address for Caper server')
     parent_server_client.add_argument(
+        '--no-server-heartbeat', action='store_true',
+        help='Disable server heartbeat file.')
+    parent_server_client.add_argument(
         '--server-heartbeat-file',
         default=DEFAULT_SERVER_HEARTBEAT_FILE,
         help='Heartbeat file for Caper clients to get IP and port of a server')
@@ -645,6 +648,7 @@ def parse_caper_arguments():
     # string to boolean
     for k in [
         'dry_run',
+        'no_server_heartbeat',
         'disable_call_caching',
         'use_gsutil_over_aws_s3',
         'hold',

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -12,6 +12,7 @@ import os
 from distutils.util import strtobool
 from collections import OrderedDict
 from .caper_backend import CaperBackendDatabase
+from .caper_backend import CaperBackendGCP
 from .caper_backend import BACKENDS, BACKEND_LOCAL
 from .caper_backend import BACKEND_ALIAS_LOCAL
 from .caper_backend import BACKEND_ALIAS_SHERLOCK, BACKEND_ALIAS_SCG
@@ -47,6 +48,8 @@ DEFAULT_DEEPCOPY_EXT = 'json,tsv'
 DEFAULT_SERVER_HEARTBEAT_FILE = '~/.caper/default_server_heartbeat'
 DEFAULT_SERVER_HEARTBEAT_TIMEOUT_MS = 120000
 DEFAULT_CONF_CONTENTS = '\n\n'
+DEFAULT_GCP_CALL_CACHING_DUP_STRAT = CaperBackendGCP.CALL_CACHING_DUP_STRAT_REFERENCE
+
 DYN_FLAGS = ['--singularity', '--docker']
 INVALID_EXT_FOR_DYN_FLAG = '.wdl'
 
@@ -239,14 +242,22 @@ def parse_caper_arguments():
         '--tmp-dir', help='Temporary directory for local backend')
 
     group_gc = parent_host.add_argument_group(
-        title='GC backend arguments')
+        title='GCP backend arguments')
     group_gc.add_argument('--gcp-prj', help='GC project')
     group_gc.add_argument('--gcp-zones', help='GCP zones (e.g. us-west1-b,'
                                               'us-central1-b)')
     group_gc.add_argument(
-        '--out-gcs-bucket', help='Output GCS bucket for GC backend')
+        '--gcp-call-caching-dup-strat', default=DEFAULT_GCP_CALL_CACHING_DUP_STRAT,
+        choices=[
+            CaperBackendGCP.CALL_CACHING_DUP_STRAT_REFERENCE,
+            CaperBackendGCP.CALL_CACHING_DUP_STRAT_COPY
+        ],
+        help='Duplication strategy for call-cached outputs for GCP backend: '
+             'copy: make a copy, reference: refer to old output in metadata.json.')
     group_gc.add_argument(
-        '--tmp-gcs-bucket', help='Temporary GCS bucket for GC backend')
+        '--out-gcs-bucket', help='Output GCS bucket for GCP backend')
+    group_gc.add_argument(
+        '--tmp-gcs-bucket', help='Temporary GCS bucket for GCP backend')
 
     group_aws = parent_host.add_argument_group(
         title='AWS backend arguments')

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """CaperArgs: Command line arguments parser for Caper
 
 Author:
@@ -18,7 +17,7 @@ from .caper_backend import BACKEND_ALIAS_LOCAL
 from .caper_backend import BACKEND_ALIAS_SHERLOCK, BACKEND_ALIAS_SCG
 
 
-__version__ = '0.6.5'
+__version__ = '0.7.0'
 
 DEFAULT_JAVA_HEAP_SERVER = '10G'
 DEFAULT_JAVA_HEAP_RUN = '3G'

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -233,6 +233,14 @@ def parse_caper_arguments():
     group_cromwell.add_argument(
         '--backend-file',
         help='Custom Cromwell backend configuration file to override all')
+    group_cromwell.add_argument(
+        '--soft-glob-output', action='store_true',
+        help='Use soft-linking when globbing outputs for a filesystem that '
+             'does not allow hard-linking. e.g. beeGFS. '
+             'This flag does not work with backends based on a Docker container. '
+             'i.e. gcp and aws. Also, '
+             'it does not work with local backends (local/slurm/sge/pbs) '
+             'with --docker. However, it works fine with --singularity.')
 
     group_local = parent_host.add_argument_group(
         title='local backend arguments')
@@ -531,6 +539,7 @@ def parse_caper_arguments():
         'dry_run',
         'no_server_heartbeat',
         'disable_call_caching',
+        'soft_glob_output',
         'use_gsutil_over_aws_s3',
         'hold',
         'no_deepcopy',

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -28,6 +28,8 @@ DEFAULT_CAPER_CONF = '~/.caper/default.conf'
 DEFAULT_SINGULARITY_CACHEDIR = '~/.caper/singularity_cachedir'
 DEFAULT_CROMWELL_JAR = 'https://github.com/broadinstitute/cromwell/releases/download/47/cromwell-47.jar'
 DEFAULT_WOMTOOL_JAR = 'https://github.com/broadinstitute/cromwell/releases/download/47/womtool-47.jar'
+DEFAULT_CROMWELL_JAR_INSTALL_DIR = '~/.caper/cromwell_jar'
+DEFAULT_WOMTOOL_JAR_INSTALL_DIR = '~/.caper/womtool_jar'
 DEFAULT_DB = CaperBackendDatabase.DB_TYPE_IN_MEMORY
 DEFAULT_MYSQL_DB_IP = 'localhost'
 DEFAULT_MYSQL_DB_PORT = 3306
@@ -140,7 +142,38 @@ def process_dyn_flags(remaining_args, dyn_flags,
     return remaining_args
 
 
+def install_cromwell_jar(uri):
+    """Download cromwell-X.jar
+    """
+    from .caper_uri import CaperURI, URI_LOCAL
+    cu = CaperURI(uri)
+    if cu.uri_type == URI_LOCAL:
+        return cu.get_uri()
+    print('Downloading Cromwell JAR... {f}'.format(f=uri), file=sys.stderr)
+    path = os.path.join(
+        os.path.expanduser(DEFAULT_CROMWELL_JAR_INSTALL_DIR),
+        os.path.basename(uri))
+    return cu.copy(target_uri=path)
+
+
+def install_womtool_jar(uri):
+    """Download womtool-X.jar
+    """
+    from .caper_uri import CaperURI, URI_LOCAL
+    cu = CaperURI(uri)
+    if cu.uri_type == URI_LOCAL:
+        return cu.get_uri()
+    print('Downloading Womtool JAR... {f}'.format(f=uri), file=sys.stderr)
+    path = os.path.join(
+        os.path.expanduser(DEFAULT_WOMTOOL_JAR_INSTALL_DIR),
+        os.path.basename(uri))
+    return cu.copy(target_uri=path)
+
+
 def init_caper_conf(args):
+    """Initialize conf file for a given platform.
+    Also, download/install Cromwell/Womtool JARs.
+    """
     backend = args.get('platform')
     assert(backend in BACKENDS_WITH_ALIASES)
     if backend in (BACKEND_LOCAL, BACKEND_ALIAS_LOCAL):
@@ -165,6 +198,12 @@ def init_caper_conf(args):
     conf_file = os.path.expanduser(args.get('conf'))
     with open(conf_file, 'w') as fp:
         fp.write(contents + '\n')
+        fp.write('{key}={val}\n'.format(
+            key='cromwell',
+            val=install_cromwell_jar(DEFAULT_CROMWELL_JAR)))
+        fp.write('{key}={val}\n'.format(
+            key='womtool',
+            val=install_womtool_jar(DEFAULT_WOMTOOL_JAR)))
 
 
 def parse_caper_arguments():

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Caper backend
 """
 from collections import UserDict

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """Caper backend
 """
+from collections import UserDict
+from copy import deepcopy
+from .dict_tool import merge_dict
 
 BACKEND_GCP = 'gcp'
 BACKEND_AWS = 'aws'
@@ -34,11 +37,11 @@ def get_backend(backend):
     elif backend == BACKEND_ALIAS_LOCAL:
         backend = BACKEND_LOCAL
     if backend not in BACKENDS:
-        raise Exception('Unsupported backend: {}'.format(backend))
+        raise ValueError('Unsupported backend: {}'.format(backend))
     return backend
 
 
-class CaperBackendCommon(dict):
+class CaperBackendCommon(UserDict):
     """Common stanzas for all Caper backends
     """
     TEMPLATE = {
@@ -75,8 +78,7 @@ class CaperBackendCommon(dict):
 
     def __init__(self, port=None, disable_call_caching=None,
                  max_concurrent_workflows=None):
-        super(CaperBackendCommon, self).__init__(
-            CaperBackendCommon.TEMPLATE)
+        super().__init__(CaperBackendCommon.TEMPLATE)
         if port is not None:
             self['webservice']['port'] = port
         if disable_call_caching is not None:
@@ -86,7 +88,7 @@ class CaperBackendCommon(dict):
                 max_concurrent_workflows
 
 
-class CaperBackendDatabase(dict):
+class CaperBackendDatabase(UserDict):
     """Common stanzas for database
     """
     DB_TYPE_IN_MEMORY = 'in-memory'
@@ -141,8 +143,7 @@ class CaperBackendDatabase(dict):
                  postgresql_ip=None, postgresql_port=None,
                  postgresql_user=None, postgresql_password=None,
                  postgresql_name=None):
-        super(CaperBackendDatabase, self).__init__(
-            CaperBackendDatabase.TEMPLATE)
+        super().__init__(CaperBackendDatabase.TEMPLATE)
 
         if db_type == CaperBackendDatabase.DB_TYPE_IN_MEMORY:
             self['database'] = CaperBackendDatabase.TEMPLATE_DB_IN_MEMORY
@@ -171,13 +172,103 @@ class CaperBackendDatabase(dict):
             db['password'] = postgresql_password
 
         else:
-            raise Exception('Unsupported DB type {}'.format(db_type))
+            raise ValueError('Unsupported DB type {}'.format(db_type))
 
         if db_timeout is not None and 'db' in self['database']:
             self['database']['db']['connectionTimeout'] = db_timeout
 
 
-class CaperBackendGCP(dict):
+class CaperBackendBase(UserDict):
+    """Base skeleton backend for all backends
+    """
+    CONCURRENT_JOB_LIMIT = None
+    TEMPLATE = {
+        "backend": {
+            "providers": {
+            }
+        }
+    }
+    TEMPLATE_BACKEND = {
+        "actor-factory": None,
+        "config": {
+            "default-runtime-attributes": {
+            },
+            "concurrent-job-limit": None
+        }
+    }
+
+    def __init__(self, dict_to_override_self=None, backend_name=None):
+        """
+        Args:
+            dict_to_override_self: dict to override self
+            backend_name: backend name
+        """
+        if backend_name is None:
+            raise ValueError('backend_name must be provided.')
+        self._backend_name = backend_name
+
+        super().__init__(deepcopy(CaperBackendBase.TEMPLATE))
+
+        config = self.get_backend_config()
+
+        if CaperBackendBase.CONCURRENT_JOB_LIMIT is None:
+            raise ValueError('You must define CaperBackendBase.CONCURRENT_JOB_LIMIT.')
+        config['concurrent-job-limit'] = CaperBackendBase.CONCURRENT_JOB_LIMIT
+
+        if dict_to_override_self is not None:
+            merge_dict(self, deepcopy(dict_to_override_self))
+
+    @property
+    def backend_name(self):
+        return self._backend_name
+
+    def get_backend(self):
+        if self._backend_name not in self['backend']['providers']:
+            self['backend']['providers'][self._backend_name] = \
+                    deepcopy(CaperBackendBase.TEMPLATE_BACKEND)
+        return self['backend']['providers'][self._backend_name]
+
+    def get_backend_config(self):
+        return self.get_backend()['config']
+
+
+class CaperBackendBaseLocal(CaperBackendBase):
+    """Base backend for all local backends (including HPCs with cluster engine)
+    """
+    USE_SOFT_GLOB_OUTPUT = None
+    OUT_DIR = None
+
+    SOFT_GLOB_OUTPUT_CMD = 'ln -sL GLOB_PATTERN GLOB_DIRECTORY 2> /dev/null'
+
+    TEMPLATE_BACKEND = {
+        "actor-factory": "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory",
+        "config": {
+            "script-epilogue": "sleep 10 && sync",
+            "root": None
+        }
+    }
+    def __init__(self, dict_to_override_self=None, backend_name=None):
+        super().__init__(backend_name=backend_name)
+
+        merge_dict(
+            self.get_backend(),
+            deepcopy(CaperBackendBaseLocal.TEMPLATE_BACKEND))
+        config = self.get_backend_config()
+
+        if CaperBackendBaseLocal.USE_SOFT_GLOB_OUTPUT is None:
+            raise ValueError('You must define CaperBackendBase.USE_SOFT_GLOB_OUTPUT.')
+        if CaperBackendBaseLocal.USE_SOFT_GLOB_OUTPUT:
+            config['glob-link-command'] = CaperBackendBaseLocal.SOFT_GLOB_OUTPUT_CMD
+
+        if CaperBackendBaseLocal.OUT_DIR is None:
+            raise ValueError('You must define CaperBackendBase.OUT_DIR.')
+        config['root'] = CaperBackendBaseLocal.OUT_DIR
+
+        if dict_to_override_self is not None:
+            merge_dict(self, deepcopy(dict_to_override_self))
+
+
+class CaperBackendGCP(CaperBackendBase):
     """Google Cloud backend
     """
     CALL_CACHING_DUP_STRAT_REFERENCE = 'reference'
@@ -187,14 +278,12 @@ class CaperBackendGCP(dict):
         "backend": {
             "providers": {
                 BACKEND_GCP: {
-                    "actor-factory": "cromwell.backend.google.pipelines."
-                    "v2alpha1.PipelinesApiLifecycleActorFactory",
+                    "actor-factory": "cromwell.backend.google.pipelines.v2alpha1.PipelinesApiLifecycleActorFactory",
                     "config": {
                         "default-runtime-attributes": {
                         },
-                        "project": "YOUR_GCP_PROJECT",
-                        "root": "gs://YOUR_GCS_BUCKET",
-                        "concurrent-job-limit": 1000,
+                        "project": None,
+                        "root": None,
                         "genomics-api-queries-per-100-seconds": 1000,
                         "maximum-polling-interval": 600,
                         "genomics": {
@@ -207,7 +296,7 @@ class CaperBackendGCP(dict):
                             "gcs": {
                                 "auth": "application-default",
                                 "caching": {
-                                    "duplication-strategy": CALL_CACHING_DUP_STRAT_REFERENCE
+                                    "duplication-strategy": None
                                 }
                             }
                         }
@@ -226,41 +315,47 @@ class CaperBackendGCP(dict):
         }
     }
 
-    def __init__(self, gcp_prj, out_gcs_bucket, concurrent_job_limit=None,
+    def __init__(self, gcp_prj, out_gcs_bucket,
                  call_caching_dup_strat=None):
-        super(CaperBackendGCP, self).__init__(
-            CaperBackendGCP.TEMPLATE)
-        config = self['backend']['providers'][BACKEND_GCP]['config']
+        super().__init__(
+            CaperBackendGCP.TEMPLATE,
+            backend_name=BACKEND_GCP)
+        config = self.get_backend_config()
+
         config['project'] = gcp_prj
         config['root'] = out_gcs_bucket
-        assert(out_gcs_bucket.startswith('gs://'))
 
-        if concurrent_job_limit is not None:
-            config['concurrent-job-limit'] = concurrent_job_limit
-        if call_caching_dup_strat is not None:
-            assert call_caching_dup_strat in (
-                CaperBackendGCP.CALL_CACHING_DUP_STRAT_REFERENCE,
-                CaperBackendGCP.CALL_CACHING_DUP_STRAT_COPY)
-            config['filesystems']['gcs']['caching']['duplication-strategy'] = call_caching_dup_strat
+        if not out_gcs_bucket.startswith('gs://'):
+            raise ValueError('Wrong GCS bucket URI for out_gcs_bucket: {v}'.format(
+                v=out_gcs_bucket))
+
+        if call_caching_dup_strat is None:
+            dup_strat = CaperBackendGCP.CALL_CACHING_DUP_STRAT_REFERENCE
+        else:
+            dup_strat = call_caching_dup_strat
+        if dup_strat not in (
+            CaperBackendGCP.CALL_CACHING_DUP_STRAT_REFERENCE,
+            CaperBackendGCP.CALL_CACHING_DUP_STRAT_COPY):
+            raise ValueError('Wrong call_caching_dup_strat: {v}'.format(
+                v=call_caching_dup_strat))
+        config['filesystems']['gcs']['caching']['duplication-strategy'] = dup_strat
 
 
-class CaperBackendAWS(dict):
+class CaperBackendAWS(CaperBackendBase):
     """AWS backend
     """
     TEMPLATE = {
         "backend": {
             "providers": {
                 BACKEND_AWS: {
-                    "actor-factory": "cromwell.backend.impl.aws."
-                    "AwsBatchBackendLifecycleActorFactory",
+                    "actor-factory": "cromwell.backend.impl.aws.AwsBatchBackendLifecycleActorFactory",
                     "config": {
                         "default-runtime-attributes": {
-                            "queueArn": "YOUR_AWS_BATCH_ARN"
+                            "queueArn": None
                         },
                         "numSubmitAttempts": 6,
                         "numCreateDefinitionAttempts": 6,
-                        "root": "s3://YOUR_S3_BUCKET",
-                        "concurrent-job-limit": 1000,
+                        "root": None,
                         "auth": "default",
                         "filesystems": {
                             "s3": {
@@ -279,7 +374,7 @@ class CaperBackendAWS(dict):
                     "scheme": "default"
                 }
             ],
-            "region": "YOUR_AWS_REGION"
+            "region": None
         },
         "engine": {
             "filesystems": {
@@ -290,21 +385,20 @@ class CaperBackendAWS(dict):
         }
     }
 
-    def __init__(self, aws_batch_arn, aws_region, out_s3_bucket,
-                 concurrent_job_limit=None):
-        super(CaperBackendAWS, self).__init__(
-            CaperBackendAWS.TEMPLATE)
+    def __init__(self, aws_batch_arn, aws_region, out_s3_bucket):
+        super().__init__(
+            CaperBackendAWS.TEMPLATE,
+            backend_name=BACKEND_AWS)
         self[BACKEND_AWS]['region'] = aws_region
-        config = self['backend']['providers'][BACKEND_AWS]['config']
+        config = self.get_backend_config()
         config['default-runtime-attributes']['queueArn'] = aws_batch_arn
         config['root'] = out_s3_bucket
-        assert(out_s3_bucket.startswith('s3://'))
+        if not out_s3_bucket.startswith('s3://'):
+            raise ValueError('Wrong S3 bucket URI for out_s3_bucket: {v}'.format(
+                v=out_s3_bucket))
 
-        if concurrent_job_limit is not None:
-            config['concurrent-job-limit'] = concurrent_job_limit
 
-
-class CaperBackendLocal(dict):
+class CaperBackendLocal(CaperBackendBaseLocal):
     """Local backend
     """
     RUNTIME_ATTRIBUTES = """
@@ -341,14 +435,8 @@ class CaperBackendLocal(dict):
         "backend": {
             "providers": {
                 BACKEND_LOCAL: {
-                    "actor-factory": "cromwell.backend.impl.sfs.config."
-                    "ConfigBackendLifecycleActorFactory",
                     "config": {
-                        "default-runtime-attributes": {
-                        },
                         "run-in-background": True,
-                        "script-epilogue": "sleep 10 && sync",
-                        "concurrent-job-limit": 1000,
                         "runtime-attributes": RUNTIME_ATTRIBUTES,
                         "submit": SUBMIT,
                         "submit-docker" : SUBMIT_DOCKER
@@ -358,17 +446,13 @@ class CaperBackendLocal(dict):
         }
     }
 
-    def __init__(self, out_dir, concurrent_job_limit=None):
-        super(CaperBackendLocal, self).__init__(
-            CaperBackendLocal.TEMPLATE)
-        config = self['backend']['providers'][BACKEND_LOCAL]['config']
-        config['root'] = out_dir
-
-        if concurrent_job_limit is not None:
-            config['concurrent-job-limit'] = concurrent_job_limit
+    def __init__(self):
+        super().__init__(
+            CaperBackendLocal.TEMPLATE,
+            backend_name=BACKEND_LOCAL)
 
 
-class CaperBackendSLURM(dict):
+class CaperBackendSLURM(CaperBackendBaseLocal):
     """SLURM backend
     """
     RUNTIME_ATTRIBUTES = """
@@ -424,14 +508,10 @@ class CaperBackendSLURM(dict):
         "backend": {
             "providers": {
                 BACKEND_SLURM: {
-                    "actor-factory": "cromwell.backend.impl.sfs.config."
-                    "ConfigBackendLifecycleActorFactory",
                     "config": {
                         "default-runtime-attributes": {
                             "time": 24
                         },
-                        "script-epilogue": "sleep 10 && sync",
-                        "concurrent-job-limit": 1000,
                         "runtime-attributes": RUNTIME_ATTRIBUTES,
                         "submit": SUBMIT,
                         "kill": "scancel ${job_id}",
@@ -444,25 +524,21 @@ class CaperBackendSLURM(dict):
         }
     }
 
-    def __init__(self, out_dir, partition=None, account=None, extra_param=None,
-                 concurrent_job_limit=None):
-        super(CaperBackendSLURM, self).__init__(
-            CaperBackendSLURM.TEMPLATE)
-        config = self['backend']['providers'][BACKEND_SLURM]['config']
-        key = 'default-runtime-attributes'
-        config['root'] = out_dir
+    def __init__(self, partition=None, account=None, extra_param=None):
+        super().__init__(
+            CaperBackendSLURM.TEMPLATE,
+            backend_name=BACKEND_SLURM)
+        config = self.get_backend_config()
 
         if partition is not None and partition != '':
-            config[key]['slurm_partition'] = partition
+            config['default-runtime-attributes']['slurm_partition'] = partition
         if account is not None and account != '':
-            config[key]['slurm_account'] = account
+            config['default-runtime-attributes']['slurm_account'] = account
         if extra_param is not None and extra_param != '':
-            config[key]['slurm_extra_param'] = extra_param
-        if concurrent_job_limit is not None:
-            config['concurrent-job-limit'] = concurrent_job_limit
+            config['default-runtime-attributes']['slurm_extra_param'] = extra_param
 
 
-class CaperBackendSGE(dict):
+class CaperBackendSGE(CaperBackendBaseLocal):
     """SGE backend
     """
     RUNTIME_ATTRIBUTES = """
@@ -518,14 +594,10 @@ ${true=")m" false="" defined(memory_mb)} \
         "backend": {
             "providers": {
                 BACKEND_SGE: {
-                    "actor-factory": "cromwell.backend.impl.sfs.config."
-                    "ConfigBackendLifecycleActorFactory",
                     "config": {
                         "default-runtime-attributes": {
                             "time": 24
                         },
-                        "script-epilogue": "sleep 10 && sync",
-                        "concurrent-job-limit": 1000,
                         "runtime-attributes": RUNTIME_ATTRIBUTES,
                         "submit": SUBMIT,
                         "exit-code-timeout-seconds": 180,
@@ -538,25 +610,21 @@ ${true=")m" false="" defined(memory_mb)} \
         }
     }
 
-    def __init__(self, out_dir, pe=None, queue=None, extra_param=None,
-                 concurrent_job_limit=None):
-        super(CaperBackendSGE, self).__init__(
-            CaperBackendSGE.TEMPLATE)
-        config = self['backend']['providers'][BACKEND_SGE]['config']
-        key = 'default-runtime-attributes'
-        config['root'] = out_dir
+    def __init__(self, pe=None, queue=None, extra_param=None):
+        super().__init__(
+            CaperBackendSGE.TEMPLATE,
+            backend_name=BACKEND_SGE)
+        config = self.get_backend_config()
 
         if pe is not None and pe != '':
-            config[key]['sge_pe'] = pe
+            config['default-runtime-attributes']['sge_pe'] = pe
         if queue is not None and queue != '':
-            config[key]['sge_queue'] = queue
+            config['default-runtime-attributes']['sge_queue'] = queue
         if extra_param is not None and extra_param != '':
-            config[key]['sge_extra_param'] = extra_param
-        if concurrent_job_limit is not None:
-            config['concurrent-job-limit'] = concurrent_job_limit
+            config['default-runtime-attributes']['sge_extra_param'] = extra_param
 
 
-class CaperBackendPBS(dict):
+class CaperBackendPBS(CaperBackendBaseLocal):
     """PBS backend
     """
     RUNTIME_ATTRIBUTES = """
@@ -598,14 +666,11 @@ ${true=":0:0" false="" defined(time)} \
         "backend": {
             "providers": {
                 BACKEND_PBS: {
-                    "actor-factory": "cromwell.backend.impl.sfs.config."
-                    "ConfigBackendLifecycleActorFactory",
                     "config": {
                         "default-runtime-attributes": {
                             "time": 24
                         },
                         "script-epilogue": "sleep 30 && sync",
-                        "concurrent-job-limit": 1000,
                         "runtime-attributes": RUNTIME_ATTRIBUTES,
                         "submit": SUBMIT,
                         "exit-code-timeout-seconds": 180,
@@ -618,20 +683,16 @@ ${true=":0:0" false="" defined(time)} \
         }
     }
 
-    def __init__(self, out_dir, queue=None, extra_param=None,
-                 concurrent_job_limit=None):
-        super(CaperBackendPBS, self).__init__(
-            CaperBackendPBS.TEMPLATE)
-        config = self['backend']['providers'][BACKEND_PBS]['config']
-        key = 'default-runtime-attributes'
-        config['root'] = out_dir
+    def __init__(self, queue=None, extra_param=None):
+        super().__init__(
+            CaperBackendPBS.TEMPLATE,
+            backend_name=BACKEND_PBS)
+        config = self.get_backend_config()
 
         if queue is not None and queue != '':
-            config[key]['pbs_queue'] = queue
+            config['default-runtime-attributes']['pbs_queue'] = queue
         if extra_param is not None and extra_param != '':
-            config[key]['pbs_extra_param'] = extra_param
-        if concurrent_job_limit is not None:
-            config['concurrent-job-limit'] = concurrent_job_limit
+            config['default-runtime-attributes']['pbs_extra_param'] = extra_param
 
 
 def main():

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -180,6 +180,9 @@ class CaperBackendDatabase(dict):
 class CaperBackendGCP(dict):
     """Google Cloud backend
     """
+    CALL_CACHING_DUP_STRAT_REFERENCE = 'reference'
+    CALL_CACHING_DUP_STRAT_COPY = 'copy'
+
     TEMPLATE = {
         "backend": {
             "providers": {
@@ -202,7 +205,10 @@ class CaperBackendGCP(dict):
                         },
                         "filesystems": {
                             "gcs": {
-                                "auth": "application-default"
+                                "auth": "application-default",
+                                "caching": {
+                                    "duplication-strategy": CALL_CACHING_DUP_STRAT_REFERENCE
+                                }
                             }
                         }
                     }
@@ -220,7 +226,8 @@ class CaperBackendGCP(dict):
         }
     }
 
-    def __init__(self, gcp_prj, out_gcs_bucket, concurrent_job_limit=None):
+    def __init__(self, gcp_prj, out_gcs_bucket, concurrent_job_limit=None,
+                 call_caching_dup_strat=None):
         super(CaperBackendGCP, self).__init__(
             CaperBackendGCP.TEMPLATE)
         config = self['backend']['providers'][BACKEND_GCP]['config']
@@ -230,6 +237,11 @@ class CaperBackendGCP(dict):
 
         if concurrent_job_limit is not None:
             config['concurrent-job-limit'] = concurrent_job_limit
+        if call_caching_dup_strat is not None:
+            assert call_caching_dup_strat in (
+                CaperBackendGCP.CALL_CACHING_DUP_STRAT_REFERENCE,
+                CaperBackendGCP.CALL_CACHING_DUP_STRAT_COPY)
+            config['filesystems']['gcs']['caching']['duplication-strategy'] = call_caching_dup_strat
 
 
 class CaperBackendAWS(dict):

--- a/caper/caper_check.py
+++ b/caper/caper_check.py
@@ -9,6 +9,7 @@ import os
 from .caper_backend import BACKENDS, BACKEND_SLURM, get_backend
 
 DEFAULT_FILE_DB_PREFIX = 'caper_file_db'
+DEFAULT_CAPER_TMP_DIR_SUFFIX = '.caper_tmp'
 
 
 def check_caper_conf(args_d):
@@ -57,16 +58,16 @@ def check_caper_conf(args_d):
         args_d['out_dir'] = os.getcwd()
 
     if args_d.get('tmp_dir') is None:
-        args_d['tmp_dir'] = os.path.join(args_d['out_dir'], '.caper_tmp')
+        args_d['tmp_dir'] = os.path.join(args_d['out_dir'], DEFAULT_CAPER_TMP_DIR_SUFFIX)
 
     if args_d.get('tmp_s3_bucket') is None:
         if args_d.get('out_s3_bucket'):
             args_d['tmp_s3_bucket'] = os.path.join(args_d['out_s3_bucket'],
-                                                   '.caper_tmp')
+                                                   DEFAULT_CAPER_TMP_DIR_SUFFIX)
     if args_d.get('tmp_gcs_bucket') is None:
         if args_d.get('out_gcs_bucket'):
             args_d['tmp_gcs_bucket'] = os.path.join(args_d['out_gcs_bucket'],
-                                                    '.caper_tmp')
+                                                    DEFAULT_CAPER_TMP_DIR_SUFFIX)
     file_db = args_d.get('file_db')
     if file_db is not None:
         file_db = os.path.abspath(os.path.expanduser(file_db))

--- a/caper/caper_check.py
+++ b/caper/caper_check.py
@@ -122,4 +122,10 @@ def check_caper_conf(args_d):
                 '--out-s3-bucket (s3:// output bucket path) '
                 'is required for backend aws.')
 
+    if args_d.get('soft_glob_output') and args_d.get('use_docker'):
+        raise ValueError(
+                '--soft-glob-output and --docker are mutually exclusive. '
+                'Delocalization from docker container will fail '
+                'for soft-linked globbed outputs.')
+
     return args_d

--- a/caper/caper_check.py
+++ b/caper/caper_check.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """CaperCheck: Caper arguments/configuration checker
 
 Author:

--- a/caper/caper_init.py
+++ b/caper/caper_init.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Functions for caper init subcommand
 
 Author:

--- a/caper/caper_init.py
+++ b/caper/caper_init.py
@@ -107,6 +107,11 @@ DEFAULT_CONF_CONTENTS_GCP = """backend=gcp
 gcp-prj=
 out-gcs-bucket=
 
+# call-cached outputs will be duplicated by making a copy or reference
+#  reference: refer to old output file in metadata.json file.
+#  copy: make a copy
+gcp-call-caching-dup-strat=
+
 # DO NOT use /tmp here
 # Caper stores all important temp files and cached big data files here
 # If not defined, Caper will make .caper_tmp/ on your local output directory

--- a/caper/caper_init.py
+++ b/caper/caper_init.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Functions for caper init subcommand
+
+Author:
+    Jin Lee (leepc12@gmail.com) at ENCODE-DCC
+"""
+
+import os
+import sys
+from .caper_backend import BACKENDS, BACKENDS_WITH_ALIASES
+from .caper_backend import BACKEND_GCP, BACKEND_AWS, BACKEND_LOCAL
+from .caper_backend import BACKEND_SLURM, BACKEND_SGE, BACKEND_PBS
+from .caper_backend import BACKEND_ALIAS_LOCAL
+from .caper_backend import BACKEND_ALIAS_GOOGLE, BACKEND_ALIAS_AMAZON
+from .caper_backend import BACKEND_ALIAS_SHERLOCK, BACKEND_ALIAS_SCG
+from .caper_uri import CaperURI, URI_LOCAL
+from .caper_args import DEFAULT_CROMWELL_JAR, DEFAULT_WOMTOOL_JAR
+
+
+DEFAULT_CROMWELL_JAR_INSTALL_DIR = '~/.caper/cromwell_jar'
+DEFAULT_WOMTOOL_JAR_INSTALL_DIR = '~/.caper/womtool_jar'
+DEFAULT_CONF_CONTENTS_LOCAL = """backend=local
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+DEFAULT_CONF_CONTENTS_SHERLOCK = """backend=slurm
+slurm-partition=
+
+# DO NOT use /tmp here
+# You can use $OAK or $SCRATCH storages here.
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+
+# IMPORTANT warning for Stanford Sherlock cluster
+# ====================================================================
+# DO NOT install any codes/executables
+# (java, conda, python, caper, pipeline's WDL, pipeline's Conda env, ...) on $SCRATCH or $OAK.
+# You will see Segmentation Fault errors.
+# Install all executables on $HOME or $PI_HOME instead.
+# It's STILL OKAY to read input data from and write outputs to $SCRATCH or $OAK.
+# ====================================================================
+"""
+DEFAULT_CONF_CONTENTS_SCG = """backend=slurm
+slurm-account=
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+DEFAULT_CONF_CONTENTS_SLURM = """backend=slurm
+
+# define one of the followings (or both) according to your
+# cluster's SLURM configuration.
+slurm-partition=
+slurm-account=
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+DEFAULT_CONF_CONTENTS_SGE = """backend=sge
+sge-pe=
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+DEFAULT_CONF_CONTENTS_PBS = """backend=pbs
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+DEFAULT_CONF_CONTENTS_AWS = """backend=aws
+aws-batch-arn=
+aws-region=
+out-s3-bucket=
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+DEFAULT_CONF_CONTENTS_GCP = """backend=gcp
+gcp-prj=
+out-gcs-bucket=
+
+# DO NOT use /tmp here
+# Caper stores all important temp files and cached big data files here
+# If not defined, Caper will make .caper_tmp/ on your local output directory
+# which is defined by out-dir, --out-dir or $CWD
+# Use a local absolute path here
+tmp-dir=
+"""
+
+
+def install_cromwell_jar(uri):
+    """Download cromwell-X.jar
+    """
+    cu = CaperURI(uri)
+    if cu.uri_type == URI_LOCAL:
+        return cu.get_uri()
+    print('Downloading Cromwell JAR... {f}'.format(f=uri), file=sys.stderr)
+    path = os.path.join(
+        os.path.expanduser(DEFAULT_CROMWELL_JAR_INSTALL_DIR),
+        os.path.basename(uri))
+    return cu.copy(target_uri=path)
+
+
+def install_womtool_jar(uri):
+    """Download womtool-X.jar
+    """
+    cu = CaperURI(uri)
+    if cu.uri_type == URI_LOCAL:
+        return cu.get_uri()
+    print('Downloading Womtool JAR... {f}'.format(f=uri), file=sys.stderr)
+    path = os.path.join(
+        os.path.expanduser(DEFAULT_WOMTOOL_JAR_INSTALL_DIR),
+        os.path.basename(uri))
+    return cu.copy(target_uri=path)
+
+
+def init_caper_conf(args):
+    """Initialize conf file for a given platform.
+    Also, download/install Cromwell/Womtool JARs.
+    """
+    backend = args.get('platform')
+    assert(backend in BACKENDS_WITH_ALIASES)
+    if backend in (BACKEND_LOCAL, BACKEND_ALIAS_LOCAL):
+        contents = DEFAULT_CONF_CONTENTS_LOCAL
+    elif backend == BACKEND_ALIAS_SHERLOCK:
+        contents = DEFAULT_CONF_CONTENTS_SHERLOCK
+    elif backend == BACKEND_ALIAS_SCG:
+        contents = DEFAULT_CONF_CONTENTS_SCG
+    elif backend == BACKEND_SLURM:
+        contents = DEFAULT_CONF_CONTENTS_SLURM
+    elif backend == BACKEND_SGE:
+        contents = DEFAULT_CONF_CONTENTS_SGE
+    elif backend == BACKEND_PBS:
+        contents = DEFAULT_CONF_CONTENTS_PBS
+    elif backend in (BACKEND_GCP, BACKEND_ALIAS_GOOGLE):
+        contents = DEFAULT_CONF_CONTENTS_GCP
+    elif backend in (BACKEND_AWS, BACKEND_ALIAS_AMAZON):
+        contents = DEFAULT_CONF_CONTENTS_AWS
+    else:
+        raise Exception('Unsupported platform/backend/alias.')
+
+    conf_file = os.path.expanduser(args.get('conf'))
+    with open(conf_file, 'w') as fp:
+        fp.write(contents + '\n')
+        fp.write('{key}={val}\n'.format(
+            key='cromwell',
+            val=install_cromwell_jar(DEFAULT_CROMWELL_JAR)))
+        fp.write('{key}={val}\n'.format(
+            key='womtool',
+            val=install_womtool_jar(DEFAULT_WOMTOOL_JAR)))

--- a/caper/caper_uri.py
+++ b/caper/caper_uri.py
@@ -203,24 +203,20 @@ class CaperURI(object):
     LOCK_MAX_ITER = 100
 
     def __init__(self, uri_or_path):
-        if CaperURI.TMP_DIR is None:
+        if CaperURI.TMP_DIR is not None and \
+            not CaperURI.TMP_DIR.endswith('/'):
             raise Exception(
-                'Call init_caper_uri() first '
-                'to initialize CaperURI. TMP_DIR must be '
-                'specified.')
-        elif not CaperURI.TMP_DIR.endswith('/'):
-            raise Exception(
-                'CaperURI.TMP_DIR must ends '
+                'CaperURI.TMP_DIR must end '
                 'with a slash (/).')
         if CaperURI.TMP_S3_BUCKET is not None and \
            not CaperURI.TMP_S3_BUCKET.endswith('/'):
             raise Exception(
-                'CaperURI.TMP_S3_BUCKET must ends '
+                'CaperURI.TMP_S3_BUCKET must end '
                 'with a slash (/).')
         if CaperURI.TMP_GCS_BUCKET is not None and \
            not CaperURI.TMP_GCS_BUCKET.endswith('/'):
             raise Exception(
-                'CaperURI.TMP_GCS_BUCKET must ends '
+                'CaperURI.TMP_GCS_BUCKET must end '
                 'with a slash (/).')
 
         self._uri = uri_or_path

--- a/caper/cromwell_rest_api.py
+++ b/caper/cromwell_rest_api.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """CromwellRestAPI
 """
 

--- a/caper/cromwell_rest_api.py
+++ b/caper/cromwell_rest_api.py
@@ -20,6 +20,9 @@ class CromwellRestAPI(object):
     ENDPOINT_ABORT = '/api/workflows/v1/{wf_id}/abort'
     ENDPOINT_RELEASE_HOLD = '/api/workflows/v1/{wf_id}/releaseHold'
     KEY_LABEL = 'cromwell_rest_api_label'
+    PARAMS_WORKFLOWS = {
+        'additionalQueryResultFields': 'labels'
+    }
 
     def __init__(self, ip='localhost', port=8000,
                  user=None, password=None, verbose=False):
@@ -198,7 +201,8 @@ class CromwellRestAPI(object):
             List of matched workflow JSONs
         """
         r = self.__request_get(
-            CromwellRestAPI.ENDPOINT_WORKFLOWS)
+            CromwellRestAPI.ENDPOINT_WORKFLOWS,
+            params=CromwellRestAPI.PARAMS_WORKFLOWS)
         if r is None:
             return None
         workflows = r['results']
@@ -215,8 +219,8 @@ class CromwellRestAPI(object):
                         break
             if w['id'] in matched:
                 continue
-            if labels is not None:
-                labels_ = self.get_labels(w['id'])
+            if labels is not None and 'labels' in w:
+                labels_ = w['labels']
                 for k, v in labels:
                     if k in labels_:
                         v_ = labels_[k]
@@ -246,7 +250,7 @@ class CromwellRestAPI(object):
         else:
             self._auth = None
 
-    def __request_get(self, endpoint):
+    def __request_get(self, endpoint, params=None):
         """GET request
 
         Returns:
@@ -257,7 +261,7 @@ class CromwellRestAPI(object):
                 port=self._port) + endpoint
         try:
             resp = requests.get(
-                url, auth=self._auth,
+                url, auth=self._auth, params=params,
                 headers={'accept': 'application/json'})
         except Exception as e:
             # traceback.print_exc()

--- a/caper/dict_tool.py
+++ b/caper/dict_tool.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """dictTool: merge/split/flatten/unflatten dict
 
 Author:


### PR DESCRIPTION
## New features
- `caper init` downloads and Cromwell/Womtool JARs and adds them to Caper's default conf file `~/.caper/default.conf` (or whatever defined with `caper -c`) so that Caper can work completely offline once those JARs are installed.
- Caper made a copy of outputs on every re-ran workflows (tasks) on GCP. Added `--gcp-call-caching-dup-strat` to control this behavior. It defaults back to `reference` instead of `copy`. Define `--gcp-call-caching-dup-strat copy` to keep making copies on re-ran (call-cached) tasks.
- Caper can soft-link globbed outputs instead of hard-linking them. This is useful on file systems where hard-linking is not allowed (e.g. beeGFS). Added a flag `--soft-glob-output` for local backends (`local`, `slurm`, `sge` and `pbs`). This flag cannot work with docker (with `--docker`) or docker-based backends (`gcp` and `aws`).

## Documentation
- Heartbeat file and how to run multiple `caper server` on a single machine.
- How to configure Caper for a custom backend.
- Important notes for storage choices on Sherlock cluster.

## Bug fixes
- `metadata.json` in output directory/bucket is updated correctly while running and after being done.
- `caper list` sent too many requests to get label of all workflows. Now it sends a single query to retrieve all information of workflows.
