### PR TITLE
subWDL zipping is for caper submit only, recursive zipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> **CRITICAL**: Caper has been updated to use [Autouri](https://github.com/ENCODE-DCC/autouri) instead of its own localization module. If you are upgrading from old Caper < 0.8. Upgrade Caper with the following commands. If it doesn't work remove Caper `pip uninstall caper` and clean-install it `pip install caper`.
+```bash
+$ pip install caper --upgrade
+```
+
 > **IMPORTANT**: If you use `--use-gsutil-for-s3` then you need to update your `gsutil`. This flag allows a direct transfer between `gs://` and `s3://`. This requires `gsutil` >= 4.47. See this [issue](https://github.com/GoogleCloudPlatform/gsutil/issues/935) for details.
 ```bash
 $ pip install gsutil --upgrade

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -409,8 +409,6 @@ class Caper(object):
         on_hold = self._hold if self._hold is not None else False
         wdl = AbsPath.localize(self._wdl)
 
-        self.__validate_with_womtool(wdl, input_file, imports_file)
-
         logger.debug(
             'submit params: wdl={w}, imports_f={imp}, input_f={i}, '
             'opt_f={o}, labels_f={l}, on_hold={on_hold}'.format(
@@ -420,6 +418,8 @@ class Caper(object):
                 o=workflow_opts_file,
                 l=labels_file,
                 on_hold=on_hold))
+
+        self.__validate_with_womtool(wdl, input_file, imports_file)
 
         if self._dry_run:
             return -1

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -17,7 +17,7 @@ from .caper_backend import BACKEND_ALIAS_LOCAL
 from .caper_backend import BACKEND_ALIAS_SHERLOCK, BACKEND_ALIAS_SCG
 
 
-__version__ = '0.7.0'
+__version__ = '0.8.0'
 
 DEFAULT_JAVA_HEAP_SERVER = '10G'
 DEFAULT_JAVA_HEAP_RUN = '3G'

--- a/caper/caper_wdl_parser.py
+++ b/caper/caper_wdl_parser.py
@@ -12,7 +12,7 @@ class CaperWDLParser(object):
         #CAPER docker ubuntu:latest
     Find subworkflows and zip it.
     """
-    RE_PATTERN_WDL_IMPORT = r'^\s*import\s+[\"\'](.+)[\"\']\s+as\s+'    
+    RE_PATTERN_WDL_IMPORT = r'^\s*import\s+[\"\'](.+)[\"\']\s*'
     RE_PATTERN_WDL_COMMENT_DOCKER = r'^\s*\#\s*CAPER\s+docker\s(.+)'
     RE_PATTERN_WDL_COMMENT_SINGULARITY = r'^\s*\#\s*CAPER\s+singularity\s(.+)'
     RECURSION_DEPTH_LIMIT = 20

--- a/caper/caper_wdl_parser.py
+++ b/caper/caper_wdl_parser.py
@@ -125,7 +125,7 @@ class CaperWDLParser(object):
                             main=self._wdl, sub=sub_rel_to_parent, i=imported_as_url))
                 print(sub_abs, main_wdl_dir, root_wdl_dir)
                 if not sub_abs.startswith(root_wdl_dir):
-                    raise FileNotFoundError(
+                    raise ValueError(
                         'Sub WDL exists but it is out of root WDL directory. '
                         'Too many "../" in your sub WDL? '
                         'Or main WDL is imported as an URL but sub WDL '

--- a/caper/caper_wdl_parser.py
+++ b/caper/caper_wdl_parser.py
@@ -131,7 +131,7 @@ class CaperWDLParser(object):
                         'Too many "../" in your sub WDL? '
                         'Or main WDL is imported as an URL but sub WDL '
                         'has "../"? '
-                        'main={main}, sub_rel={sub}, imported_as_url={i}'.format(
+                        'main={main}, sub={sub}, imported_as_url={i}'.format(
                             main=self._wdl, sub=sub_rel_to_parent, i=imported_as_url))
 
                 # make a copy on zip_dir

--- a/caper/caper_wdl_parser.py
+++ b/caper/caper_wdl_parser.py
@@ -79,7 +79,7 @@ class CaperWDLParser(object):
         Sub-WDLs imported as relative path simply inherit parent's directory.
         Sub-WDLs imported as URL does not inherit parent's directory but root 
         WDL's directory.
-        Sub-WDLs imported as absolut path are not allowed. This can work with "caper run"
+        Sub-WDLs imported as absolute path are not allowed. This can work with "caper run"
         but not with "caper submit" (or Cromwell submit).
 
         Args:

--- a/caper/caper_wdl_parser.py
+++ b/caper/caper_wdl_parser.py
@@ -128,7 +128,7 @@ class CaperWDLParser(object):
                     raise FileNotFoundError(
                         'Sub WDL exists but it is out of root WDL directory. '
                         'Too many "../" in your sub WDL? '
-                        'Or main WDL is imported as an absolute path/URL but sub WDL '
+                        'Or main WDL is imported as an URL but sub WDL '
                         'has "../"? '
                         'main={main}, sub_rel={sub}, imported_as_url={i}'.format(
                             main=self._wdl, sub=sub_rel_to_parent, i=imported_as_url))

--- a/caper/caper_wdl_parser.py
+++ b/caper/caper_wdl_parser.py
@@ -65,8 +65,11 @@ class CaperWDLParser(object):
             return num_sub_wf_packed
 
     def __recurse_subworkflow(
-        self, root_wdl_dir=None, imported_as_url=False,
-        parent_rel_to_root_wdl_dir='', root_zip_dir=None, depth=0):
+        self,
+        root_zip_dir=None,
+        root_wdl_dir=None,
+        imported_as_url=False,
+        depth=0):
         """Recurse imported sub-WDLs in main-WDL.
 
         Unlike Cromwell, Womtool does not take imports.zip while validating WDLs.
@@ -106,7 +109,6 @@ class CaperWDLParser(object):
 
             if isinstance(u_sub, HTTPURL):
                 sub_abs = u_sub.uri
-                sub_rel_to_parent = ''
                 imported_as_url_sub = True
             elif isinstance(u_sub, AbsPath):
                 raise ValueError(
@@ -133,15 +135,16 @@ class CaperWDLParser(object):
                             main=self._wdl, sub=sub_rel_to_parent, i=imported_as_url))
 
                 # make a copy on zip_dir
-                rel_path= os.path.relpath(sub_abs, main_wdl_dir)
+                rel_path = os.path.relpath(sub_abs, root_wdl_dir)
                 cp_dest = os.path.join(root_zip_dir, rel_path)
+
                 u_sub_abs.cp(cp_dest)
                 num_sub_wf_packed += 1
                 imported_as_url_sub = False
 
             num_sub_wf_packed += CaperWDLParser(sub_abs).__recurse_subworkflow(
+                root_zip_dir=root_zip_dir,
                 root_wdl_dir=root_wdl_dir,
                 imported_as_url=imported_as_url_sub,
-                parent_rel_to_root_wdl_dir=os.path.dirname(sub_rel_to_parent),
-                root_zip_dir=root_zip_dir, depth=depth + 1)
+                depth=depth + 1)
         return num_sub_wf_packed

--- a/caper/caper_wdl_parser.py
+++ b/caper/caper_wdl_parser.py
@@ -123,7 +123,6 @@ class CaperWDLParser(object):
                         'as a URL but sub WDL references a local file? '
                         'main={main}, sub={sub}, imported_as_url={i}'.format(
                             main=self._wdl, sub=sub_rel_to_parent, i=imported_as_url))
-                print(sub_abs, main_wdl_dir, root_wdl_dir)
                 if not sub_abs.startswith(root_wdl_dir):
                     raise ValueError(
                         'Sub WDL exists but it is out of root WDL directory. '


### PR DESCRIPTION
There are couple of changes for subworkflow zipping.
- Disabled it for `caper run` since users already have all WDL files localized.
- Disallow importing an absolute path in WDL (importing URL is still allowed).
- If there is a "imports" (either 1) defined by users or 2) auto-zipped by Caper while `caper submit`), then Caper will make a temporary directory and unpack such zip on it and make a copy of the main WDL there. Then run Womtool on it. We do need this workaround since Womtool cannot take an imports file in a command line arguments.

About the sub WDL imports issue reported by @keenangraham for the dnase-seq-pipeline:

Cromwell server makes a temporary sandboxed directory and unpack `imports.zip` (defined by `workflowDependencies`) there along with the main WDL file (defined by `workflowSource`). So Cromwell actually limits subworkflows to be relative to this root sandbox directory.

Caper should not be modifying any WDL files (either main or subs) and zipping files on parent directories is not possible. So possible workaround would be making a wrapper WDL like.

For example of `wdl/workflows/call_hotspots_and_peaks_and_get_spot_score.wdl` in `dnase-seq-pipeline`. All subworkflows are under `wdl/`. So make a wrapper WDL on `wdl/` like `wdl/wrapper_workflows_call_hotspots_and_peaks_and_get_spot_score` and `caper submit` it. Input JSON can be ugly that all parameter keys should be prefixed with `wrapper.`.
