### PR TITLE
PIP-1039

### DIFF
--- a/caper/caper.py
+++ b/caper/caper.py
@@ -30,7 +30,7 @@ from subprocess import Popen, check_call, PIPE, CalledProcessError
 from datetime import datetime
 from autouri import AutoURI, AbsPath, GCSURI, S3URI, URIBase
 from autouri import logger as autouri_logger
-from autouri.loc_aux import recurse_json, recurse_tsv, recurse_csv
+from autouri.loc_aux import recurse_json
 from tempfile import TemporaryDirectory
 from .dict_tool import merge_dict
 from .caper_args import parse_caper_arguments

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -28,8 +28,9 @@ from threading import Thread
 import shutil
 from subprocess import Popen, check_call, PIPE, CalledProcessError
 from datetime import datetime
-from autouri import AutoURI, AbsPath, GCSURI, S3URI
+from autouri import AutoURI, AbsPath, GCSURI, S3URI, URIBase
 from autouri import logger as autouri_logger
+from autouri.loc_aux import recurse_json, recurse_tsv, recurse_csv
 from tempfile import TemporaryDirectory
 from .dict_tool import merge_dict
 from .caper_args import parse_caper_arguments
@@ -1158,40 +1159,43 @@ class Caper(object):
 
     @staticmethod
     def __find_singularity_bindpath(input_json_file):
-        """Read input JSON file and find paths to be bound for singularity
-        by finding common roots for all files in input JSON file
+        """Find paths to be bound for singularity
+        by finding common roots for all files in input JSON file.
+        This function will recursively visit all values in input JSON and
+        also JSON, TSV, CSV files in the input JSON itself.
+
+        This function visit all files in input JSON.
+        Files with some extensions (defined by Autouri's URIBase.LOC_RECURSE_EXT_AND_FNC)
+        are recursively visited.
+
+        Args:
+            input_json_file:
+                localized input JSON file so that all files in it are already
+                recursively localized
         """
         with open(input_json_file, 'r') as fp:
-            input_json = json.loads(fp.read())
+            input_json_contents = fp.read()
 
-        # find dirname of all files
-        def recurse_dict(d, d_parent=None, d_parent_key=None,
-                         lst=None, lst_idx=None):
-            result = set()
-            if isinstance(d, dict):
-                for k, v in d.items():
-                    result |= recurse_dict(v, d_parent=d,
-                                           d_parent_key=k)
-            elif isinstance(d, list):
-                for i, v in enumerate(d):
-                    result |= recurse_dict(v, lst=d,
-                                           lst_idx=i)
-            elif type(d) == str:
-                assert(d_parent is not None or lst is not None)
-                u = AutoURI(d)
-                # local absolute path only
-                if isinstance(u, AbsPath) and u.is_valid:
-                    dirname, basename = os.path.split(u.uri)
-                    result.add(dirname)
+        all_dirnames = []
+        def find_dirname(s):
+            u = AbsPath(s)
+            if u.is_valid:
+                for ext, recurse_fnc_for_ext in URIBase.LOC_RECURSE_EXT_AND_FNC.items():
+                    if u.ext == ext:
+                        _, _ = recurse_fnc_for_ext(u.read(), find_dirname)
+                # file can be a soft-link
+                # singularity will want to have access to both soft-link and real one
+                # so add dirnames of both soft-link and realpath
+                all_dirnames.append(u.dirname)
+                all_dirnames.append(os.path.dirname(os.path.realpath(u.uri)))
+            return None, False
+        _, _ = recurse_json(input_json_contents, find_dirname)
 
-            return result
-
-        all_dirnames = recurse_dict(input_json)
         # add all (but not too high level<4) parent directories
-        # to all_dirnames. start from self
+        # to all_dirnames. start from original
         # e.g. /a/b/c/d/e/f/g/h with COMMON_ROOT_SEARCH_LEVEL = 5
         # add all the followings:
-        # /a/b/c/d/e/f/g/h (self)
+        # /a/b/c/d/e/f/g/h (org)
         # /a/b/c/d/e/f/g
         # /a/b/c/d/e/f
         # /a/b/c/d/e

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -17,7 +17,7 @@ from .caper_backend import BACKEND_ALIAS_LOCAL
 from .caper_backend import BACKEND_ALIAS_SHERLOCK, BACKEND_ALIAS_SCG
 
 
-__version__ = '0.8.1.1'
+__version__ = '0.8.2'
 
 DEFAULT_JAVA_HEAP_SERVER = '10G'
 DEFAULT_JAVA_HEAP_RUN = '3G'

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -516,7 +516,7 @@ class CaperBackendSLURM(CaperBackendBaseLocal):
                         "kill": "scancel ${job_id}",
                         "exit-code-timeout-seconds": 360,
                         "check-alive": CHECK_ALIVE,
-                        "job-id-regex": "Submitted batch job (\\\\d+).*"
+                        "job-id-regex": "Submitted batch job (\\d+).*"
                     }
                 }
             }
@@ -602,7 +602,7 @@ ${true=")m" false="" defined(memory_mb)} \
                         "exit-code-timeout-seconds": 180,
                         "kill": "qdel ${job_id}",
                         "check-alive": "qstat -j ${job_id}",
-                        "job-id-regex": "(\\\\d+)"
+                        "job-id-regex": "(\\d+)"
                     }
                 }
             }
@@ -675,7 +675,7 @@ ${true=":0:0" false="" defined(time)} \
                         "exit-code-timeout-seconds": 180,
                         "kill": "qdel ${job_id}",
                         "check-alive": "qstat ${job_id}",
-                        "job-id-regex": "(\\\\d+)"
+                        "job-id-regex": "(\\d+)"
                     }
                 }
             }

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='caper',
-    version='0.8.1.1',
+    version='0.8.2',
     python_requires='>=3.6',
     scripts=['bin/caper', 'bin/run_mysql_server_docker.sh',
              'bin/run_mysql_server_singularity.sh'],

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
     ],
-    install_requires=['pyhocon', 'requests', 'pyopenssl', 'autouri>=0.1.2.1']
+    install_requires=['pyhocon>=0.3.53', 'requests', 'pyopenssl', 'autouri>=0.1.2.1']
 )


### PR DESCRIPTION
Bug fixes
- Using symlinks in input JSON (recursively parse it to get Singularity's bindpath)
  - Old module didn't follow symlinks
  - Old module didn't find all paths in input JSON recursively (like deepcopying).
- Upgrade dependency `pyhocon` >= [0.3.53](https://github.com/chimpler/pyhocon/releases/tag/0.3.53)
  - To correctly parse escaped characters (e.g. `\\` and `\"`) in HOCON type files (`backend.conf`). Old pyhocon module parsed `\"` correctly but not `\\`. 

Dev notes:
- Singularity is not a truly isolated environment and it can still use paths outside the container, but those paths should be correctly bound to Singularity by defining `SINGULARITY_BINDPATH` env var or `-B` in cmd line arg.
- Old module didn't follow symlinks in input JSON and returned path of the symlink itself so pipeline failed because dirname of an actual file was not bound to Singularity. New module follows symlink (`os.path.realpath()`).
- To find bindpath of all files in input JSON, Caper use the same recursion function used for deep-copying (recursive localization) files in input JSON. File extensions to be recursively searched and and their corresponding recursion functions are defined in `AutoURI`'s base class `URIBase` (`URIBase.LOC_RECURSE_EXT_AND_FNC`).
