### PR TITLE
v0.8.2

### DIFF
--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -17,7 +17,7 @@ from .caper_backend import BACKEND_ALIAS_LOCAL
 from .caper_backend import BACKEND_ALIAS_SHERLOCK, BACKEND_ALIAS_SCG
 
 
-__version__ = '0.8.1'
+__version__ = '0.8.1.1'
 
 DEFAULT_JAVA_HEAP_SERVER = '10G'
 DEFAULT_JAVA_HEAP_RUN = '3G'

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -17,7 +17,7 @@ from .caper_backend import BACKEND_ALIAS_LOCAL
 from .caper_backend import BACKEND_ALIAS_SHERLOCK, BACKEND_ALIAS_SCG
 
 
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 
 DEFAULT_JAVA_HEAP_SERVER = '10G'
 DEFAULT_JAVA_HEAP_RUN = '3G'

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -17,7 +17,7 @@ from .caper_backend import BACKEND_ALIAS_LOCAL
 from .caper_backend import BACKEND_ALIAS_SHERLOCK, BACKEND_ALIAS_SCG
 
 
-__version__ = '0.8.1.1'
+__version__ = '0.8.2'
 
 DEFAULT_JAVA_HEAP_SERVER = '10G'
 DEFAULT_JAVA_HEAP_RUN = '3G'

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -516,7 +516,7 @@ class CaperBackendSLURM(CaperBackendBaseLocal):
                         "kill": "scancel ${job_id}",
                         "exit-code-timeout-seconds": 360,
                         "check-alive": CHECK_ALIVE,
-                        "job-id-regex": "Submitted batch job (\\\\d+).*"
+                        "job-id-regex": "Submitted batch job (\\d+).*"
                     }
                 }
             }
@@ -602,7 +602,7 @@ ${true=")m" false="" defined(memory_mb)} \
                         "exit-code-timeout-seconds": 180,
                         "kill": "qdel ${job_id}",
                         "check-alive": "qstat -j ${job_id}",
-                        "job-id-regex": "(\\\\d+)"
+                        "job-id-regex": "(\\d+)"
                     }
                 }
             }
@@ -675,7 +675,7 @@ ${true=":0:0" false="" defined(time)} \
                         "exit-code-timeout-seconds": 180,
                         "kill": "qdel ${job_id}",
                         "check-alive": "qstat ${job_id}",
-                        "job-id-regex": "(\\\\d+)"
+                        "job-id-regex": "(\\d+)"
                     }
                 }
             }

--- a/caper/caper_check.py
+++ b/caper/caper_check.py
@@ -55,9 +55,16 @@ def check_caper_conf(args_d):
     # init some important path variables
     if args_d.get('out_dir') is None:
         args_d['out_dir'] = os.getcwd()
+    else:
+        args_d['out_dir'] = os.path.abspath(
+            os.path.expanduser(args_d['out_dir']))
 
     if args_d.get('tmp_dir') is None:
-        args_d['tmp_dir'] = os.path.join(args_d['out_dir'], DEFAULT_CAPER_TMP_DIR_SUFFIX)
+        args_d['tmp_dir'] = os.path.abspath(
+            os.path.join(args_d['out_dir'], DEFAULT_CAPER_TMP_DIR_SUFFIX))
+    else:
+        args_d['tmp_dir'] = os.path.abspath(
+            os.path.expanduser(args_d['tmp_dir']))
 
     if args_d.get('tmp_s3_bucket') is None:
         if args_d.get('out_s3_bucket'):

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
     ],
-    install_requires=['pyhocon', 'requests', 'pyopenssl', 'autouri>=0.1.2']
+    install_requires=['pyhocon', 'requests', 'pyopenssl', 'autouri>=0.1.2.1']
 )

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 import setuptools
-import caper
+import pkg_resources
+
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name='caper',
-    version=caper.__version__,
-    python_requires='>3.4.1',
+    version=pkg_resources.get_distribution('caper').version,
+    python_requires='>=3.6',
     scripts=['bin/caper', 'bin/run_mysql_server_docker.sh',
              'bin/run_mysql_server_singularity.sh'],
     author='Jin Lee',
@@ -22,5 +23,5 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
     ],
-    install_requires=['pyhocon', 'requests', 'pyopenssl', 'autouri>=0.1.1']
+    install_requires=['pyhocon', 'requests', 'pyopenssl', 'autouri>=0.1.2']
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import setuptools
-import pkg_resources
 
 
 with open('README.md', 'r') as fh:
@@ -7,7 +6,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='caper',
-    version=pkg_resources.get_distribution('caper').version,
+    version='0.8.1',
     python_requires='>=3.6',
     scripts=['bin/caper', 'bin/run_mysql_server_docker.sh',
              'bin/run_mysql_server_singularity.sh'],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='caper',
-    version='0.8.1',
+    version='0.8.1.1',
     python_requires='>=3.6',
     scripts=['bin/caper', 'bin/run_mysql_server_docker.sh',
              'bin/run_mysql_server_singularity.sh'],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='caper',
-    version='0.8.1.1',
+    version='0.8.2',
     python_requires='>=3.6',
     scripts=['bin/caper', 'bin/run_mysql_server_docker.sh',
              'bin/run_mysql_server_singularity.sh'],
@@ -22,5 +22,5 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
     ],
-    install_requires=['pyhocon', 'requests', 'pyopenssl', 'autouri>=0.1.2.1']
+    install_requires=['pyhocon>=0.3.53', 'requests', 'pyopenssl', 'autouri>=0.1.2.1']
 )


### PR DESCRIPTION
> **IMPORTANT**: Users need to re-install Caper then it will automatically install latest bug-fixed pyhocon. Or manually upgrade `pyhocon` to >= 0.3.53.
```bash
$ pip install pyhocon==0.3.54
```
If you want to keep using old Caper versions (<0.8.2), then downgrade `pyhocon` to < 0.3.53.

Bug fixes
- Can following symlinks recursively in input JSON to get `SINGULARITY_BINDPATH`.
- `pyhocon` issue: `pyhocon` >= 0.3.53 fixed a bug for parsing escaped characters (e.g. `\\` and `\"`).
