### PR TITLE
use miniwdl to parse WDL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,6 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
     ],
-    install_requires=['pyhocon>=0.3.53', 'requests', 'pyopenssl', 'autouri>=0.1.2.1']
+    install_requires=['pyhocon>=0.3.53', 'requests', 'pyopenssl', 'autouri>=0.1.2.1',
+                      'miniwdl']
 )


### PR DESCRIPTION
Move parameters (as comments) for Caper into WDL workflow's `meta` section. This `meta` section is optional and any string key / string value is allowed.

Example for ENCODE ATAC-Seq pipeline:
```
#CAPER docker quay.io/encode-dcc/atac-seq-pipeline:dev-v1.7.1
#CAPER singularity docker://quay.io/encode-dcc/atac-seq-pipeline:dev-v1.7.1

workflow atac {
	meta {
		author: 'Jin wook Lee (leepc12@gmail.com) at ENCODE-DCC'
		description: 'ATAC-Seq/DNase-Seq pipeline'

		caper_docker: 'quay.io/encode-dcc/atac-seq-pipeline:dev-v1.7.1'
		caper_singularity: 'docker://quay.io/encode-dcc/atac-seq-pipeline:dev-v1.7.1'
	}
}
```

Also, use `miniwdl` to find imported subworkflow WDLs. This will be used for auto-zipping subworkflows.

`miniwdl`'s `WDL` package has `parse_document` function, which checks syntax of WDL but does not check imports. Use this function to get access to workflow's `meta` section.

Caper will still be able to parse comment-based parameters but it will be deprecated soon.