### PR TITLE
Pip 1086 test db

### DIFF
--- a/caper/__init__.py
+++ b/caper/__init__.py
@@ -1,4 +1,4 @@
 from .caper import Caper
 
 
-__version__ = '0.8.2'
+__version__ = '0.8.2.1'

--- a/caper/caper.py
+++ b/caper/caper.py
@@ -114,6 +114,7 @@ class Caper(object):
         self._backend_file = AbsPath.get_abspath_if_exists(
             args.get('backend_file'))
         self._soft_glob_output = args.get('soft_glob_output')
+        self._local_hash_strat = args.get('local_hash_strat')
         self._wdl = AbsPath.get_abspath_if_exists(
             args.get('wdl'))
         self._inputs = AbsPath.get_abspath_if_exists(
@@ -894,6 +895,8 @@ class Caper(object):
         # common settings for local-based backends
         if self._soft_glob_output is not None:
             CaperBackendBaseLocal.USE_SOFT_GLOB_OUTPUT = self._soft_glob_output
+        if self._local_hash_strat is not None:
+            CaperBackendBaseLocal.CALL_CACHING_HASH_STRAT = self._local_hash_strat
         if self._out_dir is not None:
             CaperBackendBaseLocal.OUT_DIR = self._out_dir
 

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -3,6 +3,7 @@ import os
 import sys
 from configparser import ConfigParser
 from distutils.util import strtobool
+from .caper_backend import CaperBackendBaseLocal
 from .caper_backend import CaperBackendDatabase
 from .caper_backend import CaperBackendGCP
 from .caper_backend import BACKENDS, BACKEND_LOCAL
@@ -236,6 +237,18 @@ def parse_caper_arguments():
              'i.e. gcp and aws. Also, '
              'it does not work with local backends (local/slurm/sge/pbs) '
              'with --docker. However, it works fine with --singularity.')
+    group_cromwell.add_argument(
+        '--local-hash-strat',
+        default=CaperBackendBaseLocal.CALL_CACHING_HASH_STRAT_FILE,
+        choices=[
+            CaperBackendBaseLocal.CALL_CACHING_HASH_STRAT_FILE,
+            CaperBackendBaseLocal.CALL_CACHING_HASH_STRAT_PATH,
+            CaperBackendBaseLocal.CALL_CACHING_HASH_STRAT_PATH_MTIME,
+        ],
+        help='File hashing strategy for call caching. '
+             'For local backends (local/slurm/sge/pbs) only. '
+             'file: use md5sum hash (slow), path: use path only, '
+             'path+modtime (default): use path + mtime.')
 
     group_local = parent_host.add_argument_group(
         title='local backend arguments')

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -103,9 +103,18 @@ class CaperBackendDatabase(UserDict):
 
     TEMPLATE_DB_FILE = {
         "db": {
-            "url": "jdbc:hsqldb:file:{file};shutdown=false;"
-                "hsqldb.tx=mvcc;hsqldb.lob_compressed=true",
-            "connectionTimeout": 5000
+            "url": "jdbc:hsqldb:file:{file};"
+                "shutdown=false;"
+                "hsqldb.tx=mvcc;"
+                "hsqldb.default_table_type=cached;"
+                "hsqldb.result_max_memory_rows=10000;"
+                "hsqldb.large_data=true;"
+                "hsqldb.applog=1;"
+                "hsqldb.lob_compressed=true;"
+                "hsqldb.script_format=3;"
+                ,
+            "connectionTimeout": 5000,
+            "numThreads": 1
         }
     }
 
@@ -118,7 +127,8 @@ class CaperBackendDatabase(UserDict):
                 "rewriteBatchedStatements=true&serverTimezone=UTC",
             "user": "cromwell",
             "password": "cromwell",
-            "connectionTimeout": 5000
+            "connectionTimeout": 5000,
+            "numThreads": 1
         }
     }
 
@@ -130,7 +140,8 @@ class CaperBackendDatabase(UserDict):
             "port": 5432,
             "user": "cromwell",
             "password": "cromwell",
-            "connectionTimeout": 5000
+            "connectionTimeout": 5000,
+            "numThreads": 1
         }
     }
 

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -107,7 +107,11 @@ class CaperBackendDatabase(UserDict):
                 "shutdown=false;"
                 "hsqldb.tx=mvcc;"
                 "hsqldb.lob_compressed=true;"
-                ,
+                "hsqldb.default_table_type=cached;"
+                "hsqldb.result_max_memory_rows=10000;"
+                "hsqldb.large_data=true;"
+                "hsqldb.applog=1;"
+                "hsqldb.script_format=3",
             "connectionTimeout": 5000,
             "numThreads": 1
         }

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -106,12 +106,8 @@ class CaperBackendDatabase(UserDict):
             "url": "jdbc:hsqldb:file:{file};"
                 "shutdown=false;"
                 "hsqldb.tx=mvcc;"
-                "hsqldb.default_table_type=cached;"
-                "hsqldb.result_max_memory_rows=10000;"
-                "hsqldb.large_data=true;"
-                "hsqldb.applog=1;"
                 "hsqldb.lob_compressed=true;"
-                "hsqldb.script_format=3",
+                ,
             "connectionTimeout": 5000,
             "numThreads": 1
         }

--- a/caper/caper_backend.py
+++ b/caper/caper_backend.py
@@ -111,8 +111,7 @@ class CaperBackendDatabase(UserDict):
                 "hsqldb.large_data=true;"
                 "hsqldb.applog=1;"
                 "hsqldb.lob_compressed=true;"
-                "hsqldb.script_format=3;"
-                ,
+                "hsqldb.script_format=3",
             "connectionTimeout": 5000,
             "numThreads": 1
         }

--- a/caper/caper_init.py
+++ b/caper/caper_init.py
@@ -24,16 +24,14 @@ CONF_CONTENTS_LOCAL_HASH_STRAT = """
 # Hashing strategy for call-caching (3 choices)
 # This parameter is for local (local/slurm/sge/pbs) backend only.
 # This is important for re-using outputs from previous/failed workflows.
-# "file" method has been default for Caper <= 0.8.2, which is slow.
 # Cache will miss if different strategy is used.
-# So we will keep "file" as default to be compatible with
-# old metadata DB generated with Caper <= 0.8.2.
-# But "path" is recommended for new users.
-# So we will make "path" default here.
+# "file" method has been default for all old versions of Caper.
+# So we will keep "file" as default to be compatible with old metadata DB.
+# But "path+modtime" is recommended for new users.
 #   file: md5sum hash (slow).
 #   path: path.
 #   path+modtime: path + mtime.
-local-hash-strat=path
+local-hash-strat=file
 """
 
 CONF_CONTENTS_TMP_DIR = """

--- a/caper/caper_init.py
+++ b/caper/caper_init.py
@@ -19,25 +19,39 @@ DEFAULT_CROMWELL_JAR = 'https://github.com/broadinstitute/cromwell/releases/down
 DEFAULT_WOMTOOL_JAR = 'https://github.com/broadinstitute/cromwell/releases/download/47/womtool-47.jar'
 DEFAULT_CROMWELL_JAR_INSTALL_DIR = '~/.caper/cromwell_jar'
 DEFAULT_WOMTOOL_JAR_INSTALL_DIR = '~/.caper/womtool_jar'
-DEFAULT_CONF_CONTENTS_LOCAL = """backend=local
 
-# DO NOT use /tmp here
-# Caper stores all important temp files and cached big data files here
-# If not defined, Caper will make .caper_tmp/ on your local output directory
-# which is defined by out-dir, --out-dir or $CWD
-# Use a local absolute path here
+CONF_CONTENTS_LOCAL_HASH_STRAT = """
+# Hashing strategy for call-caching (3 choices)
+# This parameter is for local (local/slurm/sge/pbs) backend only.
+# This is important for re-using outputs from previous/failed workflows.
+# "file" method has been default for Caper <= 0.8.2, which is slow.
+# Cache will miss if different strategy is used.
+# So we will keep "file" as default to be compatible with
+# old metadata DB generated with Caper <= 0.8.2.
+# But "path" is recommended for new users.
+# So we will make "path" default here.
+#   file: md5sum hash (slow).
+#   path: path.
+#   path+modtime: path + mtime.
+local-hash-strat=path
+"""
+
+CONF_CONTENTS_TMP_DIR = """
+# Temporary cache directory.
+# DO NOT USE /tmp. Use local absolute path here.
+# Caper stores important temporary/cached files here.
+# If not defined, Caper will make .caper_tmp/ on CWD
+# or your local output directory (--out-dir).
 tmp-dir=
 """
-DEFAULT_CONF_CONTENTS_SHERLOCK = """backend=slurm
-slurm-partition=
 
-# DO NOT use /tmp here
-# You can use $OAK or $SCRATCH storages here.
-# Caper stores all important temp files and cached big data files here
-# If not defined, Caper will make .caper_tmp/ on your local output directory
-# which is defined by out-dir, --out-dir or $CWD
-# Use a local absolute path here
-tmp-dir=
+DEFAULT_CONF_CONTENTS_LOCAL = """
+backend=local
+""" + CONF_CONTENTS_LOCAL_HASH_STRAT + CONF_CONTENTS_TMP_DIR
+
+DEFAULT_CONF_CONTENTS_SHERLOCK = """
+backend=slurm
+slurm-partition=
 
 # IMPORTANT warning for Stanford Sherlock cluster
 # ====================================================================
@@ -47,78 +61,49 @@ tmp-dir=
 # Install all executables on $HOME or $PI_HOME instead.
 # It's STILL OKAY to read input data from and write outputs to $SCRATCH or $OAK.
 # ====================================================================
-"""
-DEFAULT_CONF_CONTENTS_SCG = """backend=slurm
+""" + CONF_CONTENTS_LOCAL_HASH_STRAT + CONF_CONTENTS_TMP_DIR
+
+DEFAULT_CONF_CONTENTS_SCG = """
+backend=slurm
 slurm-account=
 
-# DO NOT use /tmp here
-# Caper stores all important temp files and cached big data files here
-# If not defined, Caper will make .caper_tmp/ on your local output directory
-# which is defined by out-dir, --out-dir or $CWD
-# Use a local absolute path here
-tmp-dir=
-"""
-DEFAULT_CONF_CONTENTS_SLURM = """backend=slurm
+""" + CONF_CONTENTS_LOCAL_HASH_STRAT + CONF_CONTENTS_TMP_DIR
+
+DEFAULT_CONF_CONTENTS_SLURM = """
+backend=slurm
 
 # define one of the followings (or both) according to your
 # cluster's SLURM configuration.
 slurm-partition=
 slurm-account=
+""" + CONF_CONTENTS_LOCAL_HASH_STRAT + CONF_CONTENTS_TMP_DIR
 
-# DO NOT use /tmp here
-# Caper stores all important temp files and cached big data files here
-# If not defined, Caper will make .caper_tmp/ on your local output directory
-# which is defined by out-dir, --out-dir or $CWD
-# Use a local absolute path here
-tmp-dir=
-"""
-DEFAULT_CONF_CONTENTS_SGE = """backend=sge
+DEFAULT_CONF_CONTENTS_SGE = """
+backend=sge
 sge-pe=
+""" + CONF_CONTENTS_LOCAL_HASH_STRAT + CONF_CONTENTS_TMP_DIR
 
-# DO NOT use /tmp here
-# Caper stores all important temp files and cached big data files here
-# If not defined, Caper will make .caper_tmp/ on your local output directory
-# which is defined by out-dir, --out-dir or $CWD
-# Use a local absolute path here
-tmp-dir=
-"""
-DEFAULT_CONF_CONTENTS_PBS = """backend=pbs
+DEFAULT_CONF_CONTENTS_PBS = """
+backend=pbs
+""" + CONF_CONTENTS_LOCAL_HASH_STRAT + CONF_CONTENTS_TMP_DIR
 
-# DO NOT use /tmp here
-# Caper stores all important temp files and cached big data files here
-# If not defined, Caper will make .caper_tmp/ on your local output directory
-# which is defined by out-dir, --out-dir or $CWD
-# Use a local absolute path here
-tmp-dir=
-"""
-DEFAULT_CONF_CONTENTS_AWS = """backend=aws
+DEFAULT_CONF_CONTENTS_AWS = """
+backend=aws
 aws-batch-arn=
 aws-region=
 out-s3-bucket=
+""" + CONF_CONTENTS_TMP_DIR
 
-# DO NOT use /tmp here
-# Caper stores all important temp files and cached big data files here
-# If not defined, Caper will make .caper_tmp/ on your local output directory
-# which is defined by out-dir, --out-dir or $CWD
-# Use a local absolute path here
-tmp-dir=
-"""
-DEFAULT_CONF_CONTENTS_GCP = """backend=gcp
+DEFAULT_CONF_CONTENTS_GCP = """
+backend=gcp
 gcp-prj=
 out-gcs-bucket=
 
-# call-cached outputs will be duplicated by making a copy or reference
-#  reference: refer to old output file in metadata.json file.
-#  copy: make a copy
+# Call-cached outputs will be duplicated by making a copy or reference
+#   reference: refer to old output file in metadata.json file.
+#   copy: make a copy.
 gcp-call-caching-dup-strat=
-
-# DO NOT use /tmp here
-# Caper stores all important temp files and cached big data files here
-# If not defined, Caper will make .caper_tmp/ on your local output directory
-# which is defined by out-dir, --out-dir or $CWD
-# Use a local absolute path here
-tmp-dir=
-"""
+""" + CONF_CONTENTS_TMP_DIR
 
 
 def install_cromwell_jar(uri):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='caper',
-    version='0.8.2',
+    version='0.8.2.1',
     python_requires='>=3.6',
     scripts=['bin/caper', 'bin/run_mysql_server_docker.sh',
              'bin/run_mysql_server_singularity.sh'],


### PR DESCRIPTION
Added `--local-hash-strat`.
- Local hashing strategy is for local backends (local/sge/slurm/pbs) only.

While testing with various metadata DB, I found that using hashing strategy `file`, which calculates md5 hash of every input file to check cache hit. This can impact on performance especially when `caper server/run` runs on a system with limited resources (e.g. login nodes).

There are three hashing strategies.
- `file`: md5sum hash. Slow and might be reason for being killed on login nodes.
- `path`: use path only, Cromwell's output is already written on a directory with workflow UUID. So it's always safe unless users directly modify files on raw output directories, which rarely happens.
- `path+modtime`: use path + mtime.

Using different strategy will lead to cache miss. Caper <= 0.8.2 defaults to use `file` method. For example, using `path` with metadata DB generated with Caper <= 0.8.2 will always cache-miss. So we will keep `file` as default.

But `caper init` will also defaults to use `file` but it will recommend new users to use `path` or `path+modtime`.
