### PR TITLE
Pip 1301 gcp server instance creation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@
     rev: v1.0.6
     hooks:
       - id: shell-lint
+        args: [--exclude, 'SC1078,SC1079']
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@
     rev: v1.0.6
     hooks:
       - id: shell-lint
-        args: [--exclude, 'SC1078,SC1079,SC2086']
+        args: [--exclude, 'SC1078,SC1079']
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@
     rev: v1.0.6
     hooks:
       - id: shell-lint
-        args: [--exclude, 'SC1078,SC1079']
+        args: [--exclude, 'SC1078,SC1079,SC2086']
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3

--- a/README.md
+++ b/README.md
@@ -612,6 +612,11 @@ This file DB is genereted on your working directory by default. Its default file
 Unless you explicitly define `file-db` in your configuration file `~/.caper/default.conf` this file DB name will depend on your input JSON filename. Therefore, you can simply resume a failed workflow with the same command line used for starting a new pipeline.
 
 
+## Caper server instance on Google Cloud
+
+We provide a shell script to create a Caper server instance on Google Cloud.
+See [this](scripts/gcp_caper_server/README.md) for details.
+
 # DETAILS
 
 See [details](DETAILS.md).

--- a/caper/__init__.py
+++ b/caper/__init__.py
@@ -2,4 +2,4 @@ from .caper_client import CaperClient, CaperClientSubmit
 from .caper_runner import CaperRunner
 
 __all__ = ['CaperClient', 'CaperClientSubmit', 'CaperRunner']
-__version__ = '1.0.1'
+__version__ = '1.1.0'

--- a/caper/__init__.py
+++ b/caper/__init__.py
@@ -2,4 +2,4 @@ from .caper_client import CaperClient, CaperClientSubmit
 from .caper_runner import CaperRunner
 
 __all__ = ['CaperClient', 'CaperClientSubmit', 'CaperRunner']
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/caper/caper_base.py
+++ b/caper/caper_base.py
@@ -92,7 +92,7 @@ class CaperBase:
                         'gcp_service_account_key_json. '
                         'Using application default credentials? '.format(env=env_name)
                     )
-            logger.info(
+            logger.debug(
                 'Adding GCP service account key JSON {key} to '
                 'env var {env}'.format(key=gcp_service_account_key_json, env=env_name)
             )

--- a/caper/caper_runner.py
+++ b/caper/caper_runner.py
@@ -224,7 +224,7 @@ class CaperRunner(CaperBase):
                         'Env var {env} does not match with '
                         'gcp_prj {prj}.'.format(env=env_name, prj=gcp_prj)
                     )
-            logger.info(
+            logger.debug(
                 'Adding {prj} to env var {env}'.format(prj=gcp_prj, env=env_name)
             )
             os.environ[env_name] = gcp_prj

--- a/caper/caper_workflow_opts.py
+++ b/caper/caper_workflow_opts.py
@@ -181,7 +181,7 @@ class CaperWorkflowOpts:
                     )
                 )
             else:
-                raise ValueError(
+                logger.warning(
                     'Docker image not found in WDL. wdl={wdl}'.format(wdl=wdl)
                 )
         if docker:

--- a/caper/cli.py
+++ b/caper/cli.py
@@ -75,7 +75,7 @@ def check_flags(args):
     singularity_flag = False
     docker_flag = False
 
-    if hasattr(args, 'singularity') and args.singularity:
+    if hasattr(args, 'singularity') and args.singularity is not None:
         singularity_flag = True
         if args.singularity.endswith(('.wdl', '.cwl')):
             raise ValueError(
@@ -84,7 +84,7 @@ def check_flags(args):
                 'singularity={p}'.format(p=args.singularity)
             )
 
-    if hasattr(args, 'docker') and args.docker:
+    if hasattr(args, 'docker') and args.docker is not None:
         docker_flag = True
         if args.docker.endswith(('.wdl', '.cwl')):
             raise ValueError(
@@ -489,7 +489,6 @@ def main(args=None, nonblocking_server=False):
     print_version(parser, known_args)
 
     parsed_args = parser.parse_args(args)
-
     init_logging(parsed_args)
     init_autouri(parsed_args)
     check_dirs(parsed_args)

--- a/caper/cli.py
+++ b/caper/cli.py
@@ -309,7 +309,7 @@ def subcmd_server(caper_runner, args, nonblocking=False):
                         'Check stdout/stderr in {file}'.format(file=cromwell_stdout)
                     )
 
-        except KeyboardInterrupt:
+        except Exception:
             logger.error(USER_INTERRUPT_WARNING)
             if thread:
                 thread.stop()
@@ -350,7 +350,7 @@ def subcmd_run(caper_runner, args):
                         'Check stdout/stderr in {file}'.format(file=cromwell_stdout)
                     )
 
-        except KeyboardInterrupt:
+        except Exception:
             logger.error(USER_INTERRUPT_WARNING)
             if thread:
                 thread.stop()

--- a/caper/cromwell.py
+++ b/caper/cromwell.py
@@ -33,9 +33,9 @@ class Cromwell:
     """Wraps Cromwell/Womtool.
     """
 
-    DEFAULT_CROMWELL = 'https://github.com/broadinstitute/cromwell/releases/download/51/cromwell-51.jar'
+    DEFAULT_CROMWELL = 'https://github.com/broadinstitute/cromwell/releases/download/52/cromwell-52.jar'
     DEFAULT_WOMTOOL = (
-        'https://github.com/broadinstitute/cromwell/releases/download/51/womtool-51.jar'
+        'https://github.com/broadinstitute/cromwell/releases/download/52/womtool-52.jar'
     )
     DEFAULT_CROMWELL_INSTALL_DIR = '~/.caper/cromwell_jar'
     DEFAULT_WOMTOOL_INSTALL_DIR = '~/.caper/womtool_jar'

--- a/caper/cromwell_metadata.py
+++ b/caper/cromwell_metadata.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 
 from autouri import AutoURI
 
@@ -82,7 +83,7 @@ class CromwellMetadata:
         """
         if 'workflowRoot' in self._metadata:
             root = self._metadata['workflowRoot']
-            metadata_file = '/'.join([root, basename])
+            metadata_file = os.path.join(root, basename)
             AutoURI(metadata_file).write(json.dumps(self._metadata, indent=4) + '\n')
             logger.info('Wrote metadata file. {f}'.format(f=metadata_file))
         else:

--- a/scripts/gcp_caper_server/README.md
+++ b/scripts/gcp_caper_server/README.md
@@ -8,13 +8,13 @@ Google Cloud Life Sciences API is a new API replacing the old deprecating Genomi
 
 Make sure that `gcloud` (Google Cloud SDK CLI) is installed on your system.
 
-Enable the following APIs on your Google Cloud console.
+Go to [APIs & Services](https://console.cloud.google.com/apis/dashboard) on your project and enable the following APIs on your Google Cloud console.
 * Compute Engine API
-* Cloud Storage (DO NOT click on "Create credentials")
+* Cloud Storage: DO NOT click on `Create credentials`.
 * Cloud Storage JSON API
-* Life Sciences API
+* Google Cloud Life Sciences API
 
-Prepare a service account with enough permission to Compute Engine, Cloud Storage, Life Sciences API and Service Account User. Generate a secret key JSON from it and keep it locally on your computer.
+Go to [Service accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) on your project and create a new service account with enough permission to Compute Engine, Cloud Storage, Life Sciences API and **Service Account User** (VERY IMPORTANT). Generate a secret key JSON from it and keep it locally on your computer.
 
 >**WARNING**: Such secret JSON file is a master key for important resources on your project. Keep it secure at your own risk. This file will be used for Caper so that it will be trasnferred to the created instance at `/opt/caper/service_account_key.json` visible to all users on the instance.
 
@@ -56,7 +56,7 @@ $ screen -RD caper_server
 # in the screen, hit CTRL+C just one time
 ```
 
-To change any parameters for Caper server/client, edit `/opt/caper/default.conf`. This file is shard among all users including `root`.
+To change any parameters for Caper server/client, edit `/opt/caper/default.conf`. This file is shared among all users including `root`.
 
 ## How to submit a workflow
 

--- a/scripts/gcp_caper_server/README.md
+++ b/scripts/gcp_caper_server/README.md
@@ -1,0 +1,62 @@
+## Introduction
+
+`create_instance.sh` will create an instance on Google Cloud Compute Engine in Google your project and configure the instance for Caper with PostgreSQL database and Google Cloud Life Sciences API (`v2beta`).
+
+Google Cloud Life Sciences API is a new API replacing deprecating old Genomics API (`v2alpha1`). It requires `--gcp-region` to be defined correctly. Check [supported regions](https://cloud.google.com/life-sciences/docs/concepts/locations) for the new API.
+
+## Requirements
+
+Make sure that `gcloud` (Google Cloud SDK CLI) is installed on your system.
+
+Enable the following APIs on your Google Cloud console.
+* Compute Engine API
+* Google Cloud Storage (DO NOT click on "Create credentials")
+* Google Cloud Storage JSON API
+* Life Sciences API
+
+Prepare a service account with enough permission to Google Compute Engine and Google Cloud Storage. Generate a secret key JSON from it and keep it locally on your computer.
+
+>**WARNING**: Such secret JSON file is a master key for important resources on your project. Keep it secure at your own risk. This file will is also used for Caper so that it will be trasnferred to the created instance at `/opt/caper/service_account_key.json` visible to all users on the instance.
+
+## How to create an instance
+
+Run without arguments to see detailed help. Some optional arguments are very important depending on your region/zone. e.g. `--gcp-region` (for Life Sciences API) and `--zone` (for instance creation). These regional parameters default to US central region/zones.
+```bash
+$ ./create_instance.sh
+```
+
+However, this script is designed to work well with default arguments. Try with positional arguments only first and see if it works.
+```bash
+$ ./create_instance.sh [PROJECT_NAME] [INSTANCE_NAME] [GCP_SERVICE_ACCOUNT_KEY_JSON_FILE] [GCP_OUT_DIR]
+```
+
+Allow several minutes for the instance to finish up installing Caper and dependencies.
+
+## How to run/stop/restart Caper server
+
+Once the instance is created. It is recommended to make a new screen so that `caper server` runs inside it without interruption. On the screen, change directory to Caper directory and run `caper server`. You can monitor Cromwell's log on `/opt/caper/cromwell.out`.
+```bash
+$ sudo su
+$ screen -RD caper_server
+# on the screen
+$ cd /opt/caper
+$ caper server
+```
+
+To stop a Caper server, open the screen with the same command line used for creating one. Then press CTRL+C just one time. **DO NOT TYPE IT MULTIPLE TIMES**. This will prevent a graceful shutdown of Cromwell, which can corrupt a metadata DB.
+```bash
+$ sudo su
+$ screen -RD caper_server
+# hit CTRL+C just one time
+```
+
+To change any parameters for Caper server/client, edit `/opt/caper/default.conf`. This file is shard among all users including `root`.
+
+## How to submit a workflow (IMPORTANT!)
+
+Check if `caper list` works without any network errors.
+```bash
+$ caper list
+```
+
+Caper will localize any files (URLs and URIs) on `/opt/caper/local_loc_dir/` e.g. your FASTQs and reference genome data defined in an input JSON.

--- a/scripts/gcp_caper_server/README.md
+++ b/scripts/gcp_caper_server/README.md
@@ -10,13 +10,19 @@ Make sure that `gcloud` (Google Cloud SDK CLI) is installed on your system.
 
 Enable the following APIs on your Google Cloud console.
 * Compute Engine API
-* Google Cloud Storage (DO NOT click on "Create credentials")
-* Google Cloud Storage JSON API
+* Cloud Storage (DO NOT click on "Create credentials")
+* Cloud Storage JSON API
 * Life Sciences API
 
-Prepare a service account with enough permission to Google Compute Engine and Google Cloud Storage. Generate a secret key JSON from it and keep it locally on your computer.
+Prepare a service account with enough permission to Compute Engine, Cloud Storage, Life Sciences API and Service Account User. Generate a secret key JSON from it and keep it locally on your computer.
 
 >**WARNING**: Such secret JSON file is a master key for important resources on your project. Keep it secure at your own risk. This file will be used for Caper so that it will be trasnferred to the created instance at `/opt/caper/service_account_key.json` visible to all users on the instance.
+
+## Troubleshooting errors
+
+If you see permission errors check if the above roles are correctly configured for your service account.
+
+If you see PAPI errors and Google's HTTP endpoint deprecation warning. Remove Life Sciences API role from your service account and add it back.
 
 ## How to create an instance
 
@@ -27,7 +33,7 @@ $ ./create_instance.sh
 
 However, this script is designed to work well with default arguments. Try with positional arguments only first and see if it works.
 ```bash
-$ ./create_instance.sh [INSTANCE_NAME] [PROJECT_NAME] [GCP_SERVICE_ACCOUNT_KEY_JSON_FILE] [GCP_OUT_DIR]
+$ ./create_instance.sh [INSTANCE_NAME] [PROJECT_ID] [GCP_SERVICE_ACCOUNT_KEY_JSON_FILE] [GCP_OUT_DIR]
 ```
 
 Allow several minutes for the instance to finish up installing Caper and dependencies.
@@ -38,7 +44,7 @@ Once the instance is created. It is recommended to make a new screen so that `ca
 ```bash
 $ sudo su
 $ screen -RD caper_server
-# on the screen
+# in the screen
 $ cd /opt/caper
 $ caper server
 ```
@@ -47,16 +53,28 @@ To stop a Caper server, open the screen with the same command line used for crea
 ```bash
 $ sudo su
 $ screen -RD caper_server
-# hit CTRL+C just one time
+# in the screen, hit CTRL+C just one time
 ```
 
 To change any parameters for Caper server/client, edit `/opt/caper/default.conf`. This file is shard among all users including `root`.
 
-## How to submit a workflow (IMPORTANT!)
+## How to submit a workflow
 
 Check if `caper list` works without any network errors.
 ```bash
 $ caper list
 ```
 
-Caper will localize big data files (URLs and URIs) on a GCS bucket directory `--gcp-loc-dir`, which defaults to `[GCP_OUT_DIR]/.caper_tmp/` if not defined. e.g. your FASTQs and reference genome data defined in an input JSON.
+Submit a workflow.
+```bash
+$ caper submit [WDL] -i input.json ...
+```
+
+Caper will localize big data files on a GCS bucket directory `--gcp-loc-dir`, which defaults to `[GCP_OUT_DIR]/.caper_tmp/` if not defined. e.g. your FASTQs and reference genome data defined in an input JSON.
+
+
+## Example
+
+```bash
+$ ./create_instance.sh xxxxxxxxxxxxx-caper-server xxxxxxxxxxxxx ~/.ssh/xxxxxxxxxxxxx-caper-server.json gs://xxxxxxxxxxxxx/caper_out --gcp-loc-dir gs://xxxxxxxxxxxxx/caper_tmp_dir --boot-disk-size 500GB
+```

--- a/scripts/gcp_caper_server/README.md
+++ b/scripts/gcp_caper_server/README.md
@@ -28,12 +28,12 @@ If you see PAPI errors and Google's HTTP endpoint deprecation warning. Remove Li
 
 Run without arguments to see detailed help. Some optional arguments are very important depending on your region/zone. e.g. `--gcp-region` (for Life Sciences API) and `--zone` (for instance creation). These regional parameters default to US central region/zones.
 ```bash
-$ ./create_instance.sh
+$ bash create_instance.sh
 ```
 
 However, this script is designed to work well with default arguments. Try with positional arguments only first and see if it works.
 ```bash
-$ ./create_instance.sh [INSTANCE_NAME] [PROJECT_ID] [GCP_SERVICE_ACCOUNT_KEY_JSON_FILE] [GCP_OUT_DIR]
+$ bash create_instance.sh [INSTANCE_NAME] [PROJECT_ID] [GCP_SERVICE_ACCOUNT_KEY_JSON_FILE] [GCP_OUT_DIR]
 ```
 
 Allow several minutes for the instance to finish up installing Caper and dependencies.

--- a/scripts/gcp_caper_server/README.md
+++ b/scripts/gcp_caper_server/README.md
@@ -2,7 +2,7 @@
 
 `create_instance.sh` will create an instance on Google Cloud Compute Engine in Google your project and configure the instance for Caper with PostgreSQL database and Google Cloud Life Sciences API (`v2beta`).
 
-Google Cloud Life Sciences API is a new API replacing deprecating old Genomics API (`v2alpha1`). It requires `--gcp-region` to be defined correctly. Check [supported regions](https://cloud.google.com/life-sciences/docs/concepts/locations) for the new API.
+Google Cloud Life Sciences API is a new API replacing the old deprecating Genomics API (`v2alpha1`). It requires `--gcp-region` to be defined correctly. Check [supported regions](https://cloud.google.com/life-sciences/docs/concepts/locations) for the new API.
 
 ## Requirements
 
@@ -16,7 +16,7 @@ Enable the following APIs on your Google Cloud console.
 
 Prepare a service account with enough permission to Google Compute Engine and Google Cloud Storage. Generate a secret key JSON from it and keep it locally on your computer.
 
->**WARNING**: Such secret JSON file is a master key for important resources on your project. Keep it secure at your own risk. This file will is also used for Caper so that it will be trasnferred to the created instance at `/opt/caper/service_account_key.json` visible to all users on the instance.
+>**WARNING**: Such secret JSON file is a master key for important resources on your project. Keep it secure at your own risk. This file will be used for Caper so that it will be trasnferred to the created instance at `/opt/caper/service_account_key.json` visible to all users on the instance.
 
 ## How to create an instance
 
@@ -27,7 +27,7 @@ $ ./create_instance.sh
 
 However, this script is designed to work well with default arguments. Try with positional arguments only first and see if it works.
 ```bash
-$ ./create_instance.sh [PROJECT_NAME] [INSTANCE_NAME] [GCP_SERVICE_ACCOUNT_KEY_JSON_FILE] [GCP_OUT_DIR]
+$ ./create_instance.sh [INSTANCE_NAME] [PROJECT_NAME] [GCP_SERVICE_ACCOUNT_KEY_JSON_FILE] [GCP_OUT_DIR]
 ```
 
 Allow several minutes for the instance to finish up installing Caper and dependencies.
@@ -59,4 +59,4 @@ Check if `caper list` works without any network errors.
 $ caper list
 ```
 
-Caper will localize any files (URLs and URIs) on `/opt/caper/local_loc_dir/` e.g. your FASTQs and reference genome data defined in an input JSON.
+Caper will localize big data files (URLs and URIs) on a GCS bucket directory `--gcp-loc-dir`, which defaults to `[GCP_OUT_DIR]/.caper_tmp/` if not defined. e.g. your FASTQs and reference genome data defined in an input JSON.

--- a/scripts/gcp_caper_server/create_instance.sh
+++ b/scripts/gcp_caper_server/create_instance.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+set -e
+
+if [[ $# -lt 1 ]]; then
+  echo "Automated shell script to create Caper server instance with PostgreSQL on Google Cloud."
+  echo
+  echo "Usage: ./create_instance.sh [INSTANCE_NAME] [GCP_PRJ]"
+  echo "                            [GCP_SERVICE_ACCOUNT_SECRET_JSON_FILE] [GCP_OUT_DIR]"
+  echo "                            <OPTIONAL_ARGUMENTS>"
+  echo
+  echo "Positional arguments:"
+  echo "  [INSTANCE_NAME]: New instance's name."
+  echo "  [GCP_PRJ]: Name of your project on Google Cloud Platform. --gcp-prj in Caper."
+  echo "  [GCP_SERVICE_ACCOUNT_KEY_JSON_FILE]: Service account's secret key JSON file. --gcp-service-account-key-json in Caper."
+  echo "  [GCP_OUT_DIR]: gs:// bucket dir path for outputs. --gcp-out-dir in Caper."
+  echo
+  echo "Optional arguments for Caper:"
+  echo "  -l, --gcp-loc-dir: gs:// bucket dir path for localization."
+  echo "  --gcp-region: Region for Google Life Sciences API. us-central1 by default. CHECK SUPPORTED REGIONS. This is different from --zone, which is used for instance creation only. us-central1 by default."
+  echo "  --postgresql-db-ip: localhost by default."
+  echo "  --postgresql-db-port: 5432 by default."
+  echo "  --postgresql-db-user: cromwell by default."
+  echo "  --postgresql-db-password: cromwell by default."
+  echo "  --postgresql-db-name: cromwell by default."
+  echo
+  echo "Optional arguments for instance creation (gcloud compute instances create):"
+  echo "  -z, --zone: Zone. Check available zones: gcloud compute zones list. us-central1-a by default."
+  echo "  -m, --machine-type: Machine type. Check available machine-types: gcloud compute machine-types list. n1-standard-4 by default."
+  echo "  -b, --boot-disk-size: Boot disk size. Use a suffix for unit. e.g. GB and MB. 100GB by default."
+  echo "  -i, --image: Image. Check available images: gcloud compute images list. ubuntu-1804-bionic-v20200716 by default."
+  echo "  --image-project: Image project. ubuntu-os-cloud by default."
+  echo "  --startup-script: Startup script CONTENTS (NOT A FILE). These command lines should sudo-install Java, PostgreSQL, Python3 and pip3. DO NOT INSTALL CAPER HERE. some apt-get command lines by default."
+  echo
+
+  if [[ $# -lt 4 ]]; then
+    echo "Define all positional arguments."
+  fi
+  exit 1
+fi
+
+# parse opt args first.
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+key="$1"
+case $key in
+  -l|--gcp-loc-dir)
+    GCP_LOC_DIR="$2"
+    shift
+    shift
+    ;;
+  --gcp-region)
+    GCP_REGION="$2"
+    shift
+    shift
+    ;;
+  --postgresql-db-ip)
+    POSTGRESQL_DB_IP="$2"
+    shift
+    shift
+    ;;
+  --postgresql-db-port)
+    POSTGRESQL_DB_PORT="$2"
+    shift
+    shift
+    ;;
+  --postgresql-db-user)
+    POSTGRESQL_DB_USER="$2"
+    shift
+    shift
+    ;;
+  --postgresql-db-password)
+    POSTGRESQL_DB_PASSWORD="$2"
+    shift
+    shift
+    ;;
+  --postgresql-db-name)
+    POSTGRESQL_DB_NAME="$2"
+    shift
+    shift
+    ;;
+  -z|--zone)
+    ZONE="$2"
+    shift
+    shift
+    ;;
+  -m|--machine-type)
+    MACHINE_TYPE="$2"
+    shift
+    shift
+    ;;
+  -b|--boot-disk-size)
+    BOOT_DISK_SIZE="$2"
+    shift
+    shift
+    ;;
+  -i|--image)
+    IMAGE="$2"
+    shift
+    shift
+    ;;
+  --image-project)
+    IMAGE_PROJECT="$2"
+    shift
+    shift
+    ;;
+  --startup-script)
+    STARTUP_SCRIPT="${2/#\~/$HOME}"
+    shift
+    shift
+    ;;
+  -e|--extra-param)
+    GCLOUD_EXTRA_PARAM="$2"
+    shift
+    shift
+    ;;
+  -*)
+    echo "Wrong parameter: $1."
+    shift
+    exit 1
+    ;;
+  *)
+    POSITIONAL+=("$1")
+    shift
+    ;;
+esac
+done
+
+# restore pos args.
+set -- "${POSITIONAL[@]}"
+
+# parse pos args.
+INSTANCE_NAME="$1"
+GCP_PRJ="$2"
+GCP_SERVICE_ACCOUNT_KEY_JSON_FILE="${3/#\~/$HOME}"
+GCP_OUT_DIR="$4"
+
+# set defaults for opt args. (caper)
+if [[ -z "$GCP_LOC_DIR" ]]; then
+  GCP_LOC_DIR="$GCP_OUT_DIR"/.caper_tmp
+fi
+if [[ -z "$GCP_REGION" ]]; then
+  GCP_REGION=us-central1
+fi
+if [[ -z "$POSTGRESQL_DB_IP" ]]; then
+  POSTGRESQL_DB_IP=localhost
+fi
+if [[ -z "$POSTGRESQL_DB_PORT" ]]; then
+  POSTGRESQL_DB_PORT=5432
+fi
+if [[ -z "$POSTGRESQL_DB_USER" ]]; then
+  POSTGRESQL_DB_USER=cromwell
+fi
+if [[ -z "$POSTGRESQL_DB_PASSWORD" ]]; then
+  POSTGRESQL_DB_PASSWORD=cromwell
+fi
+if [[ -z "$POSTGRESQL_DB_NAME" ]]; then
+  POSTGRESQL_DB_NAME=cromwell
+fi
+
+# set defaults for opt args. (gcloud)
+if [[ -z "$ZONE" ]]; then
+  ZONE=us-central1-a
+fi
+if [[ -z "$MACHINE_TYPE" ]]; then
+  MACHINE_TYPE=n1-standard-4
+fi
+if [[ -z "$BOOT_DISK_SIZE" ]]; then
+  BOOT_DISK_SIZE=100GB
+fi
+if [[ -z "$IMAGE" ]]; then
+  IMAGE=ubuntu-1804-bionic-v20200716
+fi
+if [[ -z "$IMAGE_PROJECT" ]]; then
+  IMAGE_PROJECT=ubuntu-os-cloud
+fi
+if [[ -z "$STARTUP_SCRIPT" ]]; then
+  STARTUP_SCRIPT="""#!/bin/bash
+sudo apt-get update
+sudo apt-get -y install python3 python3-pip default-jre postgresql postgresql-contrib
+"""
+fi
+
+# validate all args.
+if [[ "$GCP_OUT_DIR" != gs://* ]]; then
+  echo "[GCP_OUT_DIR] should be a GCS bucket path starting with gs://"
+  exit 1
+fi
+if [[ "$GCP_LOC_DIR" != gs://* ]]; then
+  echo "-l, --gcp-loc-dir should be a GCS bucket path starting with gs://"
+  exit 1
+fi
+if [[ ! -f "$GCP_SERVICE_ACCOUNT_KEY_JSON_FILE" ]]; then
+  echo "[GCP_SERVICE_ACCOUNT_KEY_JSON_FILE] does not exists."
+  exit 1
+fi
+if [[ "$POSTGRESQL_DB_IP" == localhost && "$POSTGRESQL_DB_PORT" != 5432 ]]; then
+  echo "--postgresql-db-port should be 5432 for locally installed PostgreSQL (--postgresql-db-ip localhost)."
+  exit 1
+fi
+
+# constants for files/params on instance.
+GCP_AUTH_SH="/etc/profile.d/gcp-auth.sh"
+CAPER_CONF_DIR=/opt/caper
+ROOT_CAPER_CONF_DIR=/root/.caper
+GLOBAL_CAPER_CONF_FILE="$CAPER_CONF_DIR/default.conf"
+REMOTE_KEY_FILE="$CAPER_CONF_DIR/service_account_key.json"
+
+# prepend more init commands to the startup-script
+STARTUP_SCRIPT="""
+### make caper's work directory
+sudo mkdir -p $CAPER_CONF_DIR
+sudo chmod +r $CAPER_CONF_DIR
+
+### make caper's out/localization directory
+sudo mkdir -p $CAPER_CONF_DIR/local_loc_dir $CAPER_CONF_DIR/local_out_dir
+sudo chmod 777 -R $CAPER_CONF_DIR/local_loc_dir $CAPER_CONF_DIR/local_out_dir
+
+### make caper conf file
+cat <<EOF > $GLOBAL_CAPER_CONF_FILE
+# caper
+backend=gcp
+no-server-heartbeat=True
+# cromwell
+max-concurrent-workflows=300
+max-concurrent-tasks=1000
+# local backend
+local-out-dir=$CAPER_CONF_DIR/local_out_dir
+local-loc-dir=$CAPER_CONF_DIR/local_loc_dir
+# gcp backend
+gcp-prj=$GCP_PRJ
+gcp-region=$GCP_REGION
+gcp-out-dir=$GCP_OUT_DIR
+gcp-loc-dir=$GCP_LOC_DIR
+gcp-service-account-key-json=$REMOTE_KEY_FILE
+use-google-cloud-life-sciences=True
+# metadata DB
+db=postgresql
+postgresql-db-ip=$POSTGRESQL_DB_IP
+postgresql-db-port=$POSTGRESQL_DB_PORT
+postgresql-db-user=$POSTGRESQL_DB_USER
+postgresql-db-password=$POSTGRESQL_DB_PASSWORD
+postgresql-db-name=$POSTGRESQL_DB_NAME
+EOF
+sudo chmod +r $GLOBAL_CAPER_CONF_FILE
+
+### soft-link conf file for root
+sudo mkdir -p $ROOT_CAPER_CONF_DIR
+sudo ln -s $GLOBAL_CAPER_CONF_FILE $ROOT_CAPER_CONF_DIR
+
+### google auth shared for all users
+sudo touch $GCP_AUTH_SH
+echo \"export GOOGLE_APPLICATION_DEFAULT=$GCP_SERVICE_ACCOUNT_KEY_JSON_FILE\" >> $GCP_AUTH_SH
+echo \"export GOOGLE_CLOUD_PROJECT=$GCP_PRJ\" >> $GCP_AUTH_SH
+echo \"mkdir -p ~/.caper\" >> $GCP_AUTH_SH
+echo \"ln -s /opt/caper/default.conf ~/.caper/ | true\" >> $GCP_AUTH_SH
+
+$STARTUP_SCRIPT
+"""
+
+# append more init commands to the startup-script
+STARTUP_SCRIPT="""$STARTUP_SCRIPT
+### init PostgreSQL for Cromwell
+sudo -u postgres createuser root -s
+sudo createdb $POSTGRESQL_DB_NAME
+sudo psql -d $POSTGRESQL_DB_NAME -c \"create extension lo;\"
+sudo psql -d $POSTGRESQL_DB_NAME -c \"create role $POSTGRESQL_DB_USER with superuser login password '$POSTGRESQL_DB_PASSWORD'\"
+
+### upgrade pip and install caper croo
+sudo python3 -m pip install --upgrade pip
+sudo pip install caper croo
+"""
+
+echo "$(date): Configuring Google Cloud's environment variables for auth..."
+export GOOGLE_APPLICATION_DEFAULT="$GCP_SERVICE_ACCOUNT_KEY_JSON_FILE"
+export GOOGLE_CLOUD_PROJECT="$GCP_PRJ"
+
+echo "$(date): Creating an instance..."
+gcloud compute instances create \
+  "$INSTANCE_NAME" \
+  --boot-disk-size="$BOOT_DISK_SIZE" \
+  --machine-type="$MACHINE_TYPE" \
+  --zone="$ZONE" \
+  --image="$IMAGE" \
+  --image-project="$IMAGE_PROJECT" \
+  --metadata startup-script="$STARTUP_SCRIPT" \
+  "$GCLOUD_EXTRA_PARAM"
+echo "$(date): Created an instance successfully."
+
+echo "$(date): Waiting for 10 seconds for the instance to spin up..."
+sleep 10
+
+echo "$(date): Transferring service account key file to instance..."
+gcloud compute scp \
+  "$GCP_SERVICE_ACCOUNT_KEY_JSON_FILE" root@"$INSTANCE_NAME":"$REMOTE_KEY_FILE" \
+  --zone="$ZONE"
+echo "$(date): Transferred a key file to instance successfully."
+
+echo "$(date): Allow several minutes for the instance to finish up installing Caper and dependencies."
+echo "$(date): Use the following command line to SSH to the instance."
+echo
+echo "gcloud beta compute ssh --zone \"$ZONE\" \"$INSTANCE_NAME\" --project \"$GCP_PRJ\""

--- a/scripts/gcp_caper_server/create_instance.sh
+++ b/scripts/gcp_caper_server/create_instance.sh
@@ -42,88 +42,88 @@ fi
 # parse opt args first.
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
-key="$1"
-case $key in
-  -l|--gcp-loc-dir)
-    GCP_LOC_DIR="$2"
-    shift
-    shift
-    ;;
-  --gcp-region)
-    GCP_REGION="$2"
-    shift
-    shift
-    ;;
-  --postgresql-db-ip)
-    POSTGRESQL_DB_IP="$2"
-    shift
-    shift
-    ;;
-  --postgresql-db-port)
-    POSTGRESQL_DB_PORT="$2"
-    shift
-    shift
-    ;;
-  --postgresql-db-user)
-    POSTGRESQL_DB_USER="$2"
-    shift
-    shift
-    ;;
-  --postgresql-db-password)
-    POSTGRESQL_DB_PASSWORD="$2"
-    shift
-    shift
-    ;;
-  --postgresql-db-name)
-    POSTGRESQL_DB_NAME="$2"
-    shift
-    shift
-    ;;
-  -z|--zone)
-    ZONE="$2"
-    shift
-    shift
-    ;;
-  -m|--machine-type)
-    MACHINE_TYPE="$2"
-    shift
-    shift
-    ;;
-  -b|--boot-disk-size)
-    BOOT_DISK_SIZE="$2"
-    shift
-    shift
-    ;;
-  --boot-disk-type)
-    BOOT_DISK_TYPE="$2"
-    shift
-    shift
-    ;;
-  --image)
-    IMAGE="$2"
-    shift
-    shift
-    ;;
-  --image-project)
-    IMAGE_PROJECT="$2"
-    shift
-    shift
-    ;;
-  --startup-script)
-    STARTUP_SCRIPT="$2"
-    shift
-    shift
-    ;;
-  -*)
-    echo "Wrong parameter: $1."
-    shift
-    exit 1
-    ;;
-  *)
-    POSITIONAL+=("$1")
-    shift
-    ;;
-esac
+  key="$1"
+  case $key in
+    -l|--gcp-loc-dir)
+      GCP_LOC_DIR="$2"
+      shift
+      shift
+      ;;
+    --gcp-region)
+      GCP_REGION="$2"
+      shift
+      shift
+      ;;
+    --postgresql-db-ip)
+      POSTGRESQL_DB_IP="$2"
+      shift
+      shift
+      ;;
+    --postgresql-db-port)
+      POSTGRESQL_DB_PORT="$2"
+      shift
+      shift
+      ;;
+    --postgresql-db-user)
+      POSTGRESQL_DB_USER="$2"
+      shift
+      shift
+      ;;
+    --postgresql-db-password)
+      POSTGRESQL_DB_PASSWORD="$2"
+      shift
+      shift
+      ;;
+    --postgresql-db-name)
+      POSTGRESQL_DB_NAME="$2"
+      shift
+      shift
+      ;;
+    -z|--zone)
+      ZONE="$2"
+      shift
+      shift
+      ;;
+    -m|--machine-type)
+      MACHINE_TYPE="$2"
+      shift
+      shift
+      ;;
+    -b|--boot-disk-size)
+      BOOT_DISK_SIZE="$2"
+      shift
+      shift
+      ;;
+    --boot-disk-type)
+      BOOT_DISK_TYPE="$2"
+      shift
+      shift
+      ;;
+    --image)
+      IMAGE="$2"
+      shift
+      shift
+      ;;
+    --image-project)
+      IMAGE_PROJECT="$2"
+      shift
+      shift
+      ;;
+    --startup-script)
+      STARTUP_SCRIPT="$2"
+      shift
+      shift
+      ;;
+    -*)
+      echo "Wrong parameter: $1."
+      shift
+      exit 1
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
 done
 
 # restore pos args.
@@ -279,7 +279,6 @@ sudo pip install caper croo
 
 echo "$(date): Google auth with service account key file."
 gcloud auth activate-service-account --key-file="$GCP_SERVICE_ACCOUNT_KEY_JSON_FILE"
-#export GOOGLE_APPLICATION_CREDENTIALS="$GCP_SERVICE_ACCOUNT_KEY_JSON_FILE"
 
 echo "$(date): Creating an instance..."
 gcloud --project "$GCP_PRJ" compute instances create \

--- a/scripts/gcp_caper_server/create_instance.sh
+++ b/scripts/gcp_caper_server/create_instance.sh
@@ -292,8 +292,10 @@ gcloud --project "$GCP_PRJ" compute instances create \
   --metadata startup-script="$STARTUP_SCRIPT"
 echo "$(date): Created an instance successfully."
 
-echo "$(date): Waiting for 30 seconds for the instance to spin up..."
-sleep 30
+while [[ $(gcloud --project "$GCP_PRJ" compute instances describe "${INSTANCE_NAME}" --zone "${ZONE}" --format="value(status)") -ne "RUNNING" ]]; do
+    echo "$(date): Waiting for 30 seconds for the instance to spin up..."
+    sleep 30
+done
 
 echo "$(date): Transferring service account key file to instance (if this fails, manually transfer key file to $REMOTE_KEY_FILE)..."
 gcloud --project "$GCP_PRJ" compute scp \

--- a/scripts/gcp_caper_server/create_instance.sh
+++ b/scripts/gcp_caper_server/create_instance.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
   echo "Automated shell script to create Caper server instance with PostgreSQL on Google Cloud."
@@ -111,11 +111,6 @@ case $key in
     ;;
   --startup-script)
     STARTUP_SCRIPT="$2"
-    shift
-    shift
-    ;;
-  -e|--extra-param)
-    GCLOUD_EXTRA_PARAM="$2"
     shift
     shift
     ;;
@@ -295,8 +290,7 @@ gcloud --project "$GCP_PRJ" compute instances create \
   --zone="$ZONE" \
   --image="$IMAGE" \
   --image-project="$IMAGE_PROJECT" \
-  --metadata startup-script="$STARTUP_SCRIPT" \
-  $GCLOUD_EXTRA_PARAM
+  --metadata startup-script="$STARTUP_SCRIPT"
 echo "$(date): Created an instance successfully."
 
 echo "$(date): Waiting for 30 seconds for the instance to spin up..."

--- a/scripts/gcp_caper_server/create_instance.sh
+++ b/scripts/gcp_caper_server/create_instance.sh
@@ -104,7 +104,7 @@ case $key in
     shift
     ;;
   --startup-script)
-    STARTUP_SCRIPT="${2/#\~/$HOME}"
+    STARTUP_SCRIPT="$2"
     shift
     shift
     ;;
@@ -174,7 +174,7 @@ if [[ -z "$IMAGE_PROJECT" ]]; then
   IMAGE_PROJECT=ubuntu-os-cloud
 fi
 if [[ -z "$STARTUP_SCRIPT" ]]; then
-  STARTUP_SCRIPT="""#!/bin/bash
+  STARTUP_SCRIPT="""
 sudo apt-get update
 sudo apt-get -y install python3 python3-pip default-jre postgresql postgresql-contrib
 """
@@ -206,7 +206,7 @@ GLOBAL_CAPER_CONF_FILE="$CAPER_CONF_DIR/default.conf"
 REMOTE_KEY_FILE="$CAPER_CONF_DIR/service_account_key.json"
 
 # prepend more init commands to the startup-script
-STARTUP_SCRIPT="""
+STARTUP_SCRIPT="""#!/bin/bash
 ### make caper's work directory
 sudo mkdir -p $CAPER_CONF_DIR
 sudo chmod +r $CAPER_CONF_DIR
@@ -274,6 +274,7 @@ echo "$(date): Configuring Google Cloud's environment variables for auth..."
 export GOOGLE_APPLICATION_DEFAULT="$GCP_SERVICE_ACCOUNT_KEY_JSON_FILE"
 export GOOGLE_CLOUD_PROJECT="$GCP_PRJ"
 
+echo "$STARTUP_SCRIPT" > x
 echo "$(date): Creating an instance..."
 gcloud compute instances create \
   "$INSTANCE_NAME" \
@@ -283,7 +284,7 @@ gcloud compute instances create \
   --image="$IMAGE" \
   --image-project="$IMAGE_PROJECT" \
   --metadata startup-script="$STARTUP_SCRIPT" \
-  "$GCLOUD_EXTRA_PARAM"
+  $GCLOUD_EXTRA_PARAM
 echo "$(date): Created an instance successfully."
 
 echo "$(date): Waiting for 10 seconds for the instance to spin up..."

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='caper',
-    version='1.0.1',
+    version='1.1.0',
     python_requires='>=3.6',
     scripts=[
         'bin/caper',

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,13 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='caper',
-    version='1.0.0',
+    version='1.0.1',
     python_requires='>=3.6',
     scripts=[
         'bin/caper',
         'bin/run_mysql_server_docker.sh',
         'bin/run_mysql_server_singularity.sh',
+        'scripts/gcp_caper_server/create_instance.sh',
     ],
     author='Jin Lee',
     author_email='leepc12@gmail.com',

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -32,7 +32,49 @@ def test_mutually_exclusive_params(tmp_path):
     cmd = ['run', str(tmp_path / 'main.wdl'), '--docker', '--singularity']
     with pytest.raises(ValueError):
         cli_main(cmd)
+
+    cmd = [
+        'run',
+        str(tmp_path / 'main.wdl'),
+        '--docker',
+        'ubuntu:latest',
+        '--singularity',
+    ]
+    with pytest.raises(ValueError):
+        cli_main(cmd)
+
+    cmd = [
+        'run',
+        str(tmp_path / 'main.wdl'),
+        '--docker',
+        '--singularity',
+        'docker://ubuntu:latest',
+    ]
+    with pytest.raises(ValueError):
+        cli_main(cmd)
+
+    cmd = [
+        'run',
+        str(tmp_path / 'main.wdl'),
+        '--docker',
+        'ubuntu:latest',
+        '--singularity',
+        'docker://ubuntu:latest',
+    ]
+    with pytest.raises(ValueError):
+        cli_main(cmd)
+
     cmd = ['run', str(tmp_path / 'main.wdl'), '--docker', '--soft-glob-output']
+    with pytest.raises(ValueError):
+        cli_main(cmd)
+
+    cmd = [
+        'run',
+        str(tmp_path / 'main.wdl'),
+        '--docker',
+        'ubuntu:latest',
+        '--soft-glob-output',
+    ]
     with pytest.raises(ValueError):
         cli_main(cmd)
 

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -25,56 +25,21 @@ def test_wrong_subcmd():
         cli_main(cmd)
 
 
-def test_mutually_exclusive_params(tmp_path):
+@pytest.mark.parametrize(
+    'cmd',
+    [
+        ['--docker', '--singularity'],
+        ['--docker', 'ubuntu:latest', '--singularity'],
+        ['--docker', '--singularity', 'docker://ubuntu:latest'],
+        ['--docker', 'ubuntu:latest', '--singularity', 'docker://ubuntu:latest'],
+        ['--docker', '--soft-glob-output'],
+        ['--docker', 'ubuntu:latest', '--soft-glob-output'],
+    ],
+)
+def test_mutually_exclusive_params(tmp_path, cmd):
     make_directory_with_wdls(str(tmp_path))
 
-    # mutually exclusive params
-    cmd = ['run', str(tmp_path / 'main.wdl'), '--docker', '--singularity']
-    with pytest.raises(ValueError):
-        cli_main(cmd)
-
-    cmd = [
-        'run',
-        str(tmp_path / 'main.wdl'),
-        '--docker',
-        'ubuntu:latest',
-        '--singularity',
-    ]
-    with pytest.raises(ValueError):
-        cli_main(cmd)
-
-    cmd = [
-        'run',
-        str(tmp_path / 'main.wdl'),
-        '--docker',
-        '--singularity',
-        'docker://ubuntu:latest',
-    ]
-    with pytest.raises(ValueError):
-        cli_main(cmd)
-
-    cmd = [
-        'run',
-        str(tmp_path / 'main.wdl'),
-        '--docker',
-        'ubuntu:latest',
-        '--singularity',
-        'docker://ubuntu:latest',
-    ]
-    with pytest.raises(ValueError):
-        cli_main(cmd)
-
-    cmd = ['run', str(tmp_path / 'main.wdl'), '--docker', '--soft-glob-output']
-    with pytest.raises(ValueError):
-        cli_main(cmd)
-
-    cmd = [
-        'run',
-        str(tmp_path / 'main.wdl'),
-        '--docker',
-        'ubuntu:latest',
-        '--soft-glob-output',
-    ]
+    cmd = ['run', str(tmp_path / 'main.wdl')] + cmd
     with pytest.raises(ValueError):
         cli_main(cmd)
 


### PR DESCRIPTION
Upgrade Cromwell from 51 to 52
- Due to change of Google API, Cromwell-51 will not work after 8/20/2020.
- Recently-created service account will not work even before 8/20/2020.

Added `scripts/gcp_caper_server/create_instance.sh`
- This script automate creation of Caper server instance on Google Cloud Platform
- Almost an one-click solution.

Lowered logging level for some annoying messages
- Exporting Google Cloud environment variables.

Bug fixes
- Double slashed directory `//` for `metadata.json` on `gs://`
- CLI can catch `SIGTERM` for graceful shutdown of Cromwell Java thread.
- Can detect mutually exclusive parameters. e.g. `--singularity` and `--docker`.
