### PR TITLE
PIP-1309 cleanup

### DIFF
--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -1,6 +1,8 @@
 import argparse
 import os
 
+from autouri import URIBase
+
 from .arg_tool import update_parsers_defaults_with_conf
 from .backward_compatibility import CAPER_1_0_0_PARAM_KEY_NAME_CHANGE
 from .caper_workflow_opts import CaperWorkflowOpts
@@ -627,6 +629,20 @@ def get_parser_and_defaults(conf_file=None):
         help='Prints gcp_monitor output in a JSON format. '
         'JSON will be more detailed then a tab-delimited one. ',
     )
+    # cleanup
+    parent_cleanup = argparse.ArgumentParser(add_help=False)
+    parent_cleanup.add_argument(
+        '--delete',
+        action='store_true',
+        help='DELETE OUTPUTS. caper cleanup runs in a dry-run mode by default. ',
+    )
+    parent_cleanup.add_argument(
+        '--num-threads',
+        default=URIBase.DEFAULT_NUM_THREADS,
+        type=int,
+        help='Number of threads for cleaning up workflow\'s outputs. '
+        'This is used for cloud backends only.',
+    )
 
     # all subcommands
     p_init = subparser.add_parser(
@@ -722,6 +738,17 @@ def get_parser_and_defaults(conf_file=None):
             parent_gcp_monitor,
         ],
     )
+    p_cleanup = subparser.add_parser(
+        'cleanup',
+        help='Cleanup outputs of workflows.',
+        parents=[
+            parent_all,
+            parent_server_client,
+            parent_client,
+            parent_search_wf,
+            parent_cleanup,
+        ],
+    )
 
     if conf_file is None:
         # partially parse args to get conf file from cmd line
@@ -741,6 +768,7 @@ def get_parser_and_defaults(conf_file=None):
         p_troubleshoot,
         p_debug,
         p_gcp_monitor,
+        p_cleanup,
     ]
     if os.path.exists(conf_file):
         conf_dict = update_parsers_defaults_with_conf(

--- a/caper/cli.py
+++ b/caper/cli.py
@@ -272,6 +272,8 @@ def client(args):
             subcmd_troubleshoot(c, args)
         elif args.action == 'gcp_monitor':
             subcmd_gcp_monitor(c, args)
+        elif args.action == 'cleanup':
+            subcmd_cleanup(c, args)
         else:
             raise ValueError('Unsupported client action {act}'.format(act=args.action))
 
@@ -477,7 +479,7 @@ def get_single_cromwell_metadata_obj(caper_client, args, subcmd):
             wf_ids_or_labels=args.wf_id_or_label, embed_subworkflow=True
         )
         if len(m) > 1:
-            raise ValueError('Found multiple workflow matching with search query.')
+            raise ValueError('Found multiple workflows matching with search query.')
         elif len(m) == 0:
             raise ValueError('Found no workflow matching with search query.')
         metadata = m[0]
@@ -524,6 +526,18 @@ def subcmd_gcp_monitor(caper_client, args):
         writer.writerow(header)
         for task_data in workflow_data:
             writer.writerow([str(v) for _, v in flatten_dict(task_data).items()])
+
+
+def subcmd_cleanup(caper_client, args):
+    """Cleanup outputs of a workflow.
+    """
+    cm = get_single_cromwell_metadata_obj(caper_client, args, 'cleanup')
+    cm.cleanup(dry_run=not args.delete, num_threads=args.num_threads)
+    if not args.delete:
+        logger.warning(
+            'Use --delete to DELETE ALL OUTPUTS of this workflow. '
+            'This action is NOT REVERSIBLE. Use this at your own risk.'
+        )
 
 
 def main(args=None, nonblocking_server=False):

--- a/caper/cromwell_metadata.py
+++ b/caper/cromwell_metadata.py
@@ -7,7 +7,7 @@ import re
 import humanfriendly
 import numpy as np
 import pandas as pd
-from autouri import GCSURI, AutoURI, URIBase
+from autouri import GCSURI, AbsPath, AutoURI, URIBase
 
 logger = logging.getLogger(__name__)
 
@@ -364,4 +364,8 @@ class CromwellMetadata:
             )
             return
 
-        AutoURI(root).rmdir(dry_run=dry_run, num_threads=num_threads)
+        if AbsPath(root).is_valid:
+            # num_threads is not available for AbsPath().rmdir()
+            AbsPath(root).rmdir(dry_run=dry_run)
+        else:
+            AutoURI(root).rmdir(dry_run=dry_run, num_threads=num_threads)

--- a/caper/cromwell_metadata.py
+++ b/caper/cromwell_metadata.py
@@ -7,7 +7,7 @@ import re
 import humanfriendly
 import numpy as np
 import pandas as pd
-from autouri import GCSURI, AutoURI
+from autouri import GCSURI, AutoURI, URIBase
 
 logger = logging.getLogger(__name__)
 
@@ -344,3 +344,24 @@ class CromwellMetadata:
         # a bit hacky way to recursively convert numpy type into python type
         json_str = json.dumps(result, default=convert_type_np_to_py)
         return json.loads(json_str)
+
+    def cleanup(self, dry_run=False, num_threads=URIBase.DEFAULT_NUM_THREADS):
+        """Cleans up workflow's root output directory.
+
+        Args:
+            dry_run:
+                Dry-run mode.
+            num_threads:
+                For outputs on cloud buckets only.
+                Number of threads for deleting individual outputs on cloud buckets in parallel.
+                Generates one client per thread. This works like `gsutil -m rm -rf`.
+        """
+        root = self._metadata.get('workflowRoot')
+        if root is None:
+            logger.error(
+                'workflowRoot not found in metadata JSON. '
+                'Cannot proceed to cleanup outputs.'
+            )
+            return
+
+        AutoURI(root).rmdir(dry_run=dry_run, num_threads=num_threads)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
         'pyhocon>=0.3.53',
         'requests',
         'pyopenssl',
-        'autouri>=0.1.2.1',
+        'autouri>=0.2.0',
         'miniwdl',
         'humanfriendly',
         'numpy',

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -12,6 +12,7 @@ import json
 import os
 
 import pytest
+from autouri import GCSURI
 
 from caper.cli import main as cli_main
 from caper.cromwell_metadata import CromwellMetadata
@@ -88,6 +89,19 @@ def test_run(tmp_path, cromwell, womtool, debug_caper):
     assert (tmp_path / 'file_db_prefix.lobs').exists()
     assert (tmp_path / 'metadata.json').exists()
     assert (tmp_path / 'cromwell_stdout.o').exists()
+
+    # test cleanup() on local storage
+    cm = CromwellMetadata(str(tmp_path / 'metadata.json'))
+    # check if metadata JSON and workflowRoot dir exists
+    root_out_dir = cm.data['workflowRoot']
+    assert os.path.exists(root_out_dir) and os.path.isdir(root_out_dir)
+
+    # dry-run should not delete anything
+    cm.cleanup(dry_run=True)
+    assert os.path.exists(root_out_dir)
+
+    cm.cleanup()
+    assert not os.path.exists(root_out_dir)
 
 
 @pytest.mark.google_cloud
@@ -174,3 +188,17 @@ def test_run_gcp_with_life_sciences_api(
             assert max_mem <= instance_mem
         if max_disk or data['task_name'] == 'main.t1':
             assert max_disk <= instance_disk
+
+    # test cleanup on gcp backend (gs://)
+    root_out_dir = cm.data['workflowRoot']
+
+    # remote metadata JSON file on workflow's root output dir.
+    remote_metadata_json_file = os.path.join(root_out_dir, 'metadata.json')
+    assert GCSURI(remote_metadata_json_file).exists
+
+    # dry-run should not delete anything
+    cm.cleanup(dry_run=False)
+    assert GCSURI(remote_metadata_json_file).exists
+
+    cm.cleanup(dry_run=True)
+    assert not GCSURI(remote_metadata_json_file).exists

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -100,7 +100,7 @@ def test_run(tmp_path, cromwell, womtool, debug_caper):
     cm.cleanup(dry_run=True)
     assert os.path.exists(root_out_dir)
 
-    cm.cleanup()
+    cm.cleanup(dry_run=False)
     assert not os.path.exists(root_out_dir)
 
 
@@ -197,8 +197,8 @@ def test_run_gcp_with_life_sciences_api(
     assert GCSURI(remote_metadata_json_file).exists
 
     # dry-run should not delete anything
-    cm.cleanup(dry_run=False)
+    cm.cleanup(dry_run=True)
     assert GCSURI(remote_metadata_json_file).exists
 
-    cm.cleanup(dry_run=True)
+    cm.cleanup(dry_run=False)
     assert not GCSURI(remote_metadata_json_file).exists


### PR DESCRIPTION
Use autouri>=0.2 `rmdir()` method to cleanup the whole output root directory.

Parameters for CLI `caper cleanup [WORKFLOW_ID_OR_METADATA_JSON_FILE]`:
- `--num-threads`: Number of threads to initiate clients. One GCS/S3 client per thread. This works like `gsutil -m rm -rf`.
- `--delete`: `caper cleanup` defaults to run in a dry-run mode. Need to explicitly define this flag to actually delete outputs.
