### PR TITLE
PIP-1341 fix memory retry

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -188,7 +188,8 @@ We highly recommend to use a default configuration file described in the section
 	use-google-cloud-life-sciences|--use-google-cloud-life-sciences|Use Google Cloud Life Sciences API instead of (deprecated) Genomics API
 	gcp-memory-retry-error-keys|--gcp-memory-retry-error-keys|If an error caught by these comma-separated keys occurs then increase instance's memory by --gcp-memory-retry-multiplier and retry (controlled by --max-retries).
 	gcp-memory-retry-multiplier|--gcp-memory-retry-multiplier|Multiplier for memory-retry.
-	gcp-zones|--gcp-zones|Comma-delimited Google Cloud Platform zones to provision worker instances (e.g. us-central1-c,us-west1-b)
+	gcp-memory-retry-returncodes|--gcp-memory-retry-returncodes|Comma-separated return codes for memory-retry. These should be valid return code from an OOM killer. e.g. 137.
+	gcp-zones|--gcp-zones|Comma-delimited Google Cloud Platform zones to provision worker instances (e.g. us-central1-c,us-west1-b). Not used if `use-google-cloud-life-sciences` flag is on.
 	gcp-out-dir, out-gcs-bucket|--gcp-out-dir, --out-gcs-bucket|Output `gs://` directory for GC backend
 	gcp-loc-dir, tmp-gcs-bucket|--gcp-loc-dir, --tmp-gcs-bucket|Tmp. directory for localization on GC backend
 

--- a/DETAILS.md
+++ b/DETAILS.md
@@ -186,12 +186,18 @@ We highly recommend to use a default configuration file described in the section
 	:-----|:-----|:-----
 	gcp-prj|--gcp-prj|Google Cloud project
 	use-google-cloud-life-sciences|--use-google-cloud-life-sciences|Use Google Cloud Life Sciences API instead of (deprecated) Genomics API
-	gcp-memory-retry-error-keys|--gcp-memory-retry-error-keys|If an error caught by these comma-separated keys occurs then increase instance's memory by --gcp-memory-retry-multiplier and retry (controlled by --max-retries).
-	gcp-memory-retry-multiplier|--gcp-memory-retry-multiplier|Multiplier for memory-retry.
-	gcp-memory-retry-returncodes|--gcp-memory-retry-returncodes|Comma-separated return codes for memory-retry. These should be valid return code from an OOM killer. e.g. 137.
 	gcp-zones|--gcp-zones|Comma-delimited Google Cloud Platform zones to provision worker instances (e.g. us-central1-c,us-west1-b). Not used if `use-google-cloud-life-sciences` flag is on.
 	gcp-out-dir, out-gcs-bucket|--gcp-out-dir, --out-gcs-bucket|Output `gs://` directory for GC backend
 	gcp-loc-dir, tmp-gcs-bucket|--gcp-loc-dir, --tmp-gcs-bucket|Tmp. directory for localization on GC backend
+
+* **DISABLED** Google Cloud Platform backend settings
+
+	**Conf. file**|**Cmd. line**|**Description**
+	:-----|:-----|:-----
+	gcp-memory-retry-error-keys|--gcp-memory-retry-error-keys|If an error caught by these comma-separated keys occurs then increase instance's memory by --gcp-memory-retry-multiplier and retry (controlled by --max-retries).
+	gcp-memory-retry-multiplier|--gcp-memory-retry-multiplier|Multiplier for memory-retry.
+	gcp-memory-retry-returncodes|--gcp-memory-retry-returncodes|Comma-separated return codes for memory-retry. These should be valid return code from an OOM killer. e.g. `[0, 137]`.
+
 
 * AWS backend settings
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![CircleCI](https://circleci.com/gh/ENCODE-DCC/caper.svg?style=svg)](https://circleci.com/gh/ENCODE-DCC/caper)
 
+> **IMPORTANT**: All `gcp-memory-retry` parameters are disabled in Caper 1.3.0. They will be re-enabled after https://github.com/broadinstitute/cromwell/issues/5815 is resolved.
+List of disabled parameters:
+- `gcp-memory-retry-error-keys`
+- `gcp-memory-retry-multiplier`
+- `gcp-memory-retry-returncodes`
+
 # Major changes for Caper 1.0.
 
 If you are upgrading Caper from previous versions:

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -316,6 +316,14 @@ def get_parser_and_defaults(conf_file=None):
         'See https://cromwell.readthedocs.io/en/stable/backends/Google/ '
         'for details.',
     )
+    group_gc.add_argument(
+        '--gcp-memory-retry-returncodes',
+        default=','.join(
+            [str(rc) for rc in CromwellBackendGCP.DEFAULT_MEMORY_RETRY_RETURNCODES]
+        ),
+        help='Comma-separated return codes for memory-retry. '
+        'This should be valid return codes from an OOM killer. e.g 137. ',
+    )
     group_gc_all.add_argument(
         '--use-google-cloud-life-sciences',
         action='store_true',

--- a/caper/caper_backend_conf.py
+++ b/caper/caper_backend_conf.py
@@ -54,6 +54,7 @@ class CaperBackendConf:
         gcp_out_dir=None,
         gcp_memory_retry_error_keys=CromwellBackendGCP.DEFAULT_MEMORY_RETRY_KEYS,
         gcp_memory_retry_multiplier=CromwellBackendGCP.DEFAULT_MEMORY_RETRY_MULTIPLIER,
+        gcp_memory_retry_returncodes=CromwellBackendGCP.DEFAULT_MEMORY_RETRY_RETURNCODES,
         gcp_call_caching_dup_strat=CromwellBackendGCP.DEFAULT_GCP_CALL_CACHING_DUP_STRAT,
         gcp_service_account_key_json=None,
         use_google_cloud_life_sciences=False,
@@ -133,6 +134,9 @@ class CaperBackendConf:
             gcp_memory_retry_error_multiplier:
                 Multiplier for GCP memory-retry.
                 See description for gcp_memory_retry_error_keys.
+            gcp_memory_retry_returncodes:
+                List of return codes for memory-retry.
+                This should be valid return codes from an OOM killer. e.g. [137].
             gcp_call_caching_dup_strat:
                 Call-caching duplication strategy.
             gcp_service_account_key_json:
@@ -272,6 +276,7 @@ class CaperBackendConf:
                     gcp_out_dir=gcp_out_dir,
                     gcp_memory_retry_error_keys=gcp_memory_retry_error_keys,
                     gcp_memory_retry_multiplier=gcp_memory_retry_multiplier,
+                    gcp_memory_retry_returncodes=gcp_memory_retry_returncodes,
                     call_caching_dup_strat=gcp_call_caching_dup_strat,
                     gcp_service_account_key_json=gcp_service_account_key_json,
                     use_google_cloud_life_sciences=use_google_cloud_life_sciences,

--- a/caper/caper_init.py
+++ b/caper/caper_init.py
@@ -140,7 +140,7 @@ gcp-region=
 gcp-zones=
 
 # Increase instance's memory when retrying upon OOM (out of memory) error.
-gcp-memory-retry-multiplier=1.2
+gcp-memory-retry-multiplier=1.5
 
 # Number of retrials. This parameter also applies to non-OOM failures.
 max-retries=1

--- a/caper/caper_runner.py
+++ b/caper/caper_runner.py
@@ -59,6 +59,7 @@ class CaperRunner(CaperBase):
         gcp_out_dir=None,
         gcp_memory_retry_error_keys=CromwellBackendGCP.DEFAULT_MEMORY_RETRY_KEYS,
         gcp_memory_retry_multiplier=CromwellBackendGCP.DEFAULT_MEMORY_RETRY_MULTIPLIER,
+        gcp_memory_retry_returncodes=CromwellBackendGCP.DEFAULT_MEMORY_RETRY_RETURNCODES,
         gcp_call_caching_dup_strat=CromwellBackendGCP.DEFAULT_GCP_CALL_CACHING_DUP_STRAT,
         gcp_service_account_key_json=None,
         use_google_cloud_life_sciences=False,
@@ -118,6 +119,7 @@ class CaperRunner(CaperBase):
             gcp_out_dir:
             gcp_memory_retry_error_keys:
             gcp_memory_retry_multiplier:
+            gcp_memory_retry_returncodes:
             aws_batch_arn:
             aws_region:
             aws_out_dir:
@@ -179,6 +181,7 @@ class CaperRunner(CaperBase):
             gcp_out_dir=gcp_out_dir,
             gcp_memory_retry_error_keys=gcp_memory_retry_error_keys,
             gcp_memory_retry_multiplier=gcp_memory_retry_multiplier,
+            gcp_memory_retry_returncodes=gcp_memory_retry_returncodes,
             gcp_call_caching_dup_strat=gcp_call_caching_dup_strat,
             gcp_service_account_key_json=gcp_service_account_key_json,
             use_google_cloud_life_sciences=use_google_cloud_life_sciences,

--- a/caper/cli.py
+++ b/caper/cli.py
@@ -168,6 +168,14 @@ def runner(args, nonblocking_server=False):
         args.gcp_memory_retry_error_keys = re.split(
             REGEX_DELIMITER_GCP_PARAMS, args.gcp_memory_retry_error_keys
         )
+    if args.gcp_memory_retry_returncodes:
+        # split comma-separated string into ints
+        args.gcp_memory_retry_returncodes = re.split(
+            REGEX_DELIMITER_GCP_PARAMS, args.gcp_memory_retry_returncodes
+        )
+        args.gcp_memory_retry_returncodes = list(
+            map(int, args.gcp_memory_retry_returncodes)
+        )
 
     c = CaperRunner(
         local_loc_dir=args.local_loc_dir,
@@ -204,6 +212,7 @@ def runner(args, nonblocking_server=False):
         gcp_out_dir=args.gcp_out_dir,
         gcp_memory_retry_error_keys=args.gcp_memory_retry_error_keys,
         gcp_memory_retry_multiplier=args.gcp_memory_retry_multiplier,
+        gcp_memory_retry_returncodes=args.gcp_memory_retry_returncodes,
         aws_batch_arn=args.aws_batch_arn,
         aws_region=args.aws_region,
         aws_out_dir=args.aws_out_dir,
@@ -371,7 +380,7 @@ def subcmd_run(caper_runner, args):
                     )
 
         except Exception:
-            logger.error(USER_INTERRUPT_WARNING)
+            logger.error(USER_INTERRUPT_WARNING, exc_info=True)
             if thread:
                 thread.stop()
 

--- a/caper/cromwell_backend.py
+++ b/caper/cromwell_backend.py
@@ -330,7 +330,9 @@ class CromwellBackendGCP(CromwellBackendBase):
                 {'name': 'application-default', 'scheme': 'application_default'}
             ]
 
-        if gcp_memory_retry_error_keys:
+        # Temporarily disabled until memory-retry issue is fixed on Cromwell's side:
+        #   https://github.com/broadinstitute/cromwell/issues/5815
+        if gcp_memory_retry_error_keys and False:
             config['memory-retry'] = {
                 'error-keys': gcp_memory_retry_error_keys,
                 'multiplier': gcp_memory_retry_multiplier,

--- a/caper/cromwell_backend.py
+++ b/caper/cromwell_backend.py
@@ -253,7 +253,11 @@ class CromwellBackendGCP(CromwellBackendBase):
     CALL_CACHING_DUP_STRAT_COPY = 'copy'
 
     DEFAULT_GCP_CALL_CACHING_DUP_STRAT = CALL_CACHING_DUP_STRAT_REFERENCE
-    DEFAULT_MEMORY_RETRY_KEYS = ['OutOfMemoryError', '[0-9]+[ \\t]Killed[ \\t]']
+    DEFAULT_MEMORY_RETRY_KEYS = [
+        'OutOfMemoryError',
+        '[0-9]+[ \\t]Killed[ \\t]',
+        '^Killed$',
+    ]
     DEFAULT_MEMORY_RETRY_MULTIPLIER = 1.5
     DEFAULT_MEMORY_RETRY_RETURNCODES = [0, 137]
 
@@ -288,6 +292,7 @@ class CromwellBackendGCP(CromwellBackendBase):
                 List of extended reguler expression strings to catch out-of-memory error.
                 Cromwell internally uses `grep -E` to parse it.
                 To disable memory-retry make this None or empty.
+                Default error keys work with `bash` (Cromwell's default) and `sh`.
             gcp_memory_retry_multiplier:
                 Multiplier for instance's memory for next memory-retry.
             gcp_memory_retry_returncodes:

--- a/caper/cromwell_metadata.py
+++ b/caper/cromwell_metadata.py
@@ -49,7 +49,7 @@ class CromwellMetadata:
         if isinstance(metadata, dict):
             self._metadata = metadata
         elif isinstance(metadata, CromwellMetadata):
-            self._metadata = metadata._metadata
+            self = metadata
         else:
             s = AutoURI(metadata).read()
             self._metadata = json.loads(s)

--- a/caper/cromwell_metadata.py
+++ b/caper/cromwell_metadata.py
@@ -49,7 +49,7 @@ class CromwellMetadata:
         if isinstance(metadata, dict):
             self._metadata = metadata
         elif isinstance(metadata, CromwellMetadata):
-            self = metadata
+            self._metadata = metadata._metadata
         else:
             s = AutoURI(metadata).read()
             self._metadata = json.loads(s)

--- a/scripts/gcp_caper_server/create_instance.sh
+++ b/scripts/gcp_caper_server/create_instance.sh
@@ -327,7 +327,7 @@ echo "$(date): Transferred a key file to instance successfully."
 
 echo "$(date): Waiting for the instance finishing up installing Caper..."
 until gcloud --project "$GCP_PRJ" compute ssh --zone="$ZONE" root@"$INSTANCE_NAME" --command="caper -v"; do
-  echo "$(date): Caper has not been installed yet. Retrying in 40 seconds..."
+  echo "$(date): Caper has not been installed yet. Retrying in 40 seconds... But this can also take several minutes..."
   sleep 40
 done
 echo "$(date): Finished installing Caper on the instance. Ready to run Caper server."

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -139,6 +139,7 @@ def test_run_gcp_with_life_sciences_api(
     cmd += ['--gcp-prj', gcp_prj]
     cmd += ['--gcp-memory-retry-error-keys', 'Killed']
     cmd += ['--gcp-memory-retry-multiplier', '1.5']
+    cmd += ['--gcp-memory-retry-returncodes', '1,137']
     cmd += ['--tmp-dir', str(tmp_path / 'tmp_dir')]
     cmd += ['--backend', 'gcp']
     cmd += ['--gcp-out-dir', out_gcs_bucket]

--- a/tests/test_cli_server_client_gcp.py
+++ b/tests/test_cli_server_client_gcp.py
@@ -46,6 +46,7 @@ def test_server_client(
     cmd += ['--gcp-out-dir', out_gcs_bucket]
     cmd += ['--gcp-memory-retry-error-keys', 'OutOfMemory,Killed']
     cmd += ['--gcp-memory-retry-multiplier', '1.3']
+    cmd += ['--gcp-memory-retry-returncodes', '1,137']
     cmd += ['--gcp-loc-dir', tmp_gcs_bucket]
     cmd += ['--cromwell-stdout', str(tmp_path / 'cromwell_stdout.o')]
     cmd += ['--db', 'in-memory']

--- a/tests/test_gcp_memory_retry.py
+++ b/tests/test_gcp_memory_retry.py
@@ -1,0 +1,83 @@
+"""Test GCP memory-retry.
+
+Default return codes for memory-retry: [0, 137]
+    137
+        - General SIGKILL (including OOM kill).
+    0
+        - Success
+
+If there is memory-retry-keyword in STDERR,
+Cromwell does memory-retry even with return code 0, which means success.
+
+It's currently (Cromwell-52) not possible to control such behavior for 0 return code.
+So it's important to carefully parse STDERR to catch OOM for 137 cases only.
+
+Cromwell's default memory-retry-keyword is ['OutOfMemoryError', 'Killed']
+    OutOfMemoryError
+        - It's Java OOM message, which is actually `java.lang.OutOfMemoryError: DESC, STACKTRACE`
+    Killed
+        - Default SIGKILL message format of `sh`.
+        - This will catch all `Killed` in STDERR. So use regex `^Killed$` instead of it.
+
+Cromwell is based on bash. So in order to precisely catch killed message.
+Use the following.
+    PID Killed CMDLINE
+        - Default SIGKILL message format of `bash`.
+        - Use [0-9]+ Killed
+"""
+import json
+import os
+
+import pytest
+
+from caper.cli import main as cli_main
+
+from .example_wdl import MEM_RETRY_WDL
+
+
+@pytest.mark.google_cloud
+@pytest.mark.integration
+def test_gcp_memory_retry(
+    tmp_path,
+    gcs_root,
+    ci_prefix,
+    cromwell,
+    womtool,
+    gcp_prj,
+    gcp_service_account_key_json,
+    debug_caper,
+):
+    """Test run with Google Cloud Life Sciences API
+    """
+    out_gcs_bucket = os.path.join(gcs_root, 'caper_out', ci_prefix)
+    tmp_gcs_bucket = os.path.join(gcs_root, 'caper_tmp')
+
+    # prepare WDLs and input JSON, imports to be submitted
+    wdl = tmp_path / 'mem_retry.wdl'
+    wdl.write_text(MEM_RETRY_WDL)
+    metadata = tmp_path / 'metadata.json'
+
+    cmd = ['run', str(wdl)]
+    cmd += ['-m', str(metadata)]
+    if gcp_service_account_key_json:
+        cmd += ['--gcp-service-account-key-json', gcp_service_account_key_json]
+    cmd += ['--use-google-cloud-life-sciences']
+    cmd += ['--gcp-region', 'us-central1']
+    cmd += ['--gcp-zones', 'us-west1-a,us-west1-b']
+    cmd += ['--gcp-prj', gcp_prj]
+    cmd += ['--tmp-dir', str(tmp_path / 'tmp_dir')]
+    cmd += ['--backend', 'gcp']
+    cmd += ['--gcp-out-dir', out_gcs_bucket]
+    cmd += ['--gcp-loc-dir', tmp_gcs_bucket]
+    cmd += ['--cromwell-stdout', str(tmp_path / 'cromwell_stdout.o')]
+    cmd += ['--db', 'in-memory']
+    cmd += ['--cromwell', cromwell]
+    cmd += ['--womtool', womtool]
+    cmd += ['--java-heap-run', '4G']
+    cmd += ['--docker', 'ubuntu:latest']
+    if debug_caper:
+        cmd += ['--debug']
+    print(' '.join(cmd))
+
+    cli_main(cmd)
+    json.loads(metadata.read_text())

--- a/tests/test_gcp_memory_retry.py
+++ b/tests/test_gcp_memory_retry.py
@@ -49,6 +49,10 @@ def test_gcp_memory_retry(
 ):
     """Test run with Google Cloud Life Sciences API
     """
+    # Temporarily disabled until memory-retry issue is fixed on Cromwell's side:
+    #   https://github.com/broadinstitute/cromwell/issues/5815
+    return
+
     out_gcs_bucket = os.path.join(gcs_root, 'caper_out', ci_prefix)
     tmp_gcs_bucket = os.path.join(gcs_root, 'caper_tmp')
 


### PR DESCRIPTION
Added `--gcp-memory-retry-returncodes` (defaults to `[0, 137]`. Without `0`, it marks successful tasks as failed.) to specify valid returncodes for memory-retry.
See [this ticket](https://encodedcc.atlassian.net/browse/PIP-1341) for details.

To activate `gcp-memory-retry`, Cromwell's `continueOnReturnCode` flag should be `true` or `[0, 137]` (at least to catch both success and SIGKILL). Setting `continueOnReturnCode` as `true` will pass all failed tasks in a workflow.
If `137` occurs due to other reasons (without `Killed` message in STDERR, so that not caught by `memory-retry` regex `grep -E 'Killed|OutOfMemoryError'`) then Cromwell will just pass such failed task and continue, which looks dangerous.

Trying to limit it to `[0, 137]` but Cromwell fails (due to other reasons) even after catching `137`.
See https://github.com/broadinstitute/cromwell/issues/5815 for details.

I think `memory-retry` is currently not very robust so disabled all `gcp-memory-retry` parameters for Caper 1.3.0.
These will be re-enabled after the issue is resolved.

Please consider this PR as just tweaking reg-ex to catch OOM (e.g. `Killed`) and adding `--gcp-memory-retry-returncodes` and corresponding test for it. After Cromwell fixes the issue on their side, I will make another PR to finish it and re-enable `memory-retry` parameters.