### PR TITLE
Pip 1358 use service account for compute

### DIFF
--- a/caper/caper_workflow_opts.py
+++ b/caper/caper_workflow_opts.py
@@ -189,12 +189,12 @@ class CaperWorkflowOpts:
                 )
             else:
                 logger.warning(
-                    'Docker image not found in WDL\'s metadata, which means that '
-                    'docker is not defined either as comment (#CAPER docker) or '
-                    'in workflow\'s meta section (under key caper_docker) in WDL. '
-                    'If your WDL already has docker defined '
-                    'in each task\'s runtime '
-                    'then it should be okay. wdl={wdl}'.format(wdl=wdl)
+                    "Docker image not found in WDL's metadata, which means that "
+                    "docker is not defined either as comment (#CAPER docker) or "
+                    "in workflow's meta section (under key caper_docker) in WDL. "
+                    "If your WDL already has docker defined "
+                    "in each task's runtime "
+                    "then it should be okay. wdl={wdl}".format(wdl=wdl)
                 )
         if docker:
             dra['docker'] = docker

--- a/caper/caper_workflow_opts.py
+++ b/caper/caper_workflow_opts.py
@@ -183,13 +183,13 @@ class CaperWorkflowOpts:
             docker = wdl_parser.caper_docker
             if docker:
                 logger.info(
-                    'Ddocker image found in WDL. wdl={wdl}, d={d}'.format(
+                    'Docker image found in WDL\'s metadata. wdl={wdl}, d={d}'.format(
                         wdl=wdl, d=docker
                     )
                 )
             else:
                 logger.warning(
-                    'Docker image not found in WDL, which means that '
+                    'Docker image not found in WDL\'s metadata, which means that '
                     'docker is not defined either as comment (#CAPER docker) or '
                     'in workflow\'s meta section (under key caper_docker) in WDL. '
                     'If your WDL already has docker defined '
@@ -208,7 +208,7 @@ class CaperWorkflowOpts:
             singularity = wdl_parser.caper_singularity
             if singularity:
                 logger.info(
-                    'Singularity image found in WDL. wdl={wdl}, s={s}'.format(
+                    'Singularity image found in WDL\'s metadata. wdl={wdl}, s={s}'.format(
                         wdl=wdl, s=singularity
                     )
                 )

--- a/caper/caper_workflow_opts.py
+++ b/caper/caper_workflow_opts.py
@@ -183,13 +183,18 @@ class CaperWorkflowOpts:
             docker = wdl_parser.caper_docker
             if docker:
                 logger.info(
-                    'Docker image found in WDL. wdl={wdl}, d={d}'.format(
+                    'Ddocker image found in WDL. wdl={wdl}, d={d}'.format(
                         wdl=wdl, d=docker
                     )
                 )
             else:
                 logger.warning(
-                    'Docker image not found in WDL. wdl={wdl}'.format(wdl=wdl)
+                    'Docker image not found in WDL, which means that '
+                    'docker is not defined either as comment (#CAPER docker) or '
+                    'in workflow\'s meta section (under key caper_docker) in WDL. '
+                    'If your WDL already has docker defined '
+                    'in each task\'s runtime '
+                    'then it should be okay. wdl={wdl}'.format(wdl=wdl)
                 )
         if docker:
             dra['docker'] = docker

--- a/caper/cli.py
+++ b/caper/cli.py
@@ -311,21 +311,23 @@ def subcmd_server(caper_runner, args, nonblocking=False):
             heartbeat_timeout=args.server_heartbeat_timeout,
         )
 
+    kwargs = {
+        'default_backend': args.backend,
+        'server_port': args.port,
+        'server_heartbeat': sh,
+        'custom_backend_conf': get_abspath(args.backend_file),
+        'embed_subworkflow': True,
+        'java_heap_server': args.java_heap_server,
+        'dry_run': args.dry_run,
+    }
+
+    if nonblocking:
+        return caper_runner.server(fileobj_stdout=sys.stdout, **kwargs)
+
     cromwell_stdout = get_abspath(args.cromwell_stdout)
     with open(cromwell_stdout, 'w') as f:
         try:
-            thread = caper_runner.server(
-                default_backend=args.backend,
-                server_port=args.port,
-                server_heartbeat=sh,
-                custom_backend_conf=get_abspath(args.backend_file),
-                fileobj_stdout=sys.stdout if nonblocking else f,
-                embed_subworkflow=True,
-                java_heap_server=args.java_heap_server,
-                dry_run=args.dry_run,
-            )
-            if nonblocking:
-                return thread
+            thread = caper_runner.server(fileobj_stdout=f, **kwargs)
             if thread:
                 thread.join()
                 if thread.returncode:

--- a/caper/cli.py
+++ b/caper/cli.py
@@ -311,7 +311,7 @@ def subcmd_server(caper_runner, args, nonblocking=False):
             heartbeat_timeout=args.server_heartbeat_timeout,
         )
 
-    kwargs = {
+    args_from_cli = {
         'default_backend': args.backend,
         'server_port': args.port,
         'server_heartbeat': sh,
@@ -322,12 +322,12 @@ def subcmd_server(caper_runner, args, nonblocking=False):
     }
 
     if nonblocking:
-        return caper_runner.server(fileobj_stdout=sys.stdout, **kwargs)
+        return caper_runner.server(fileobj_stdout=sys.stdout, **args_from_cli)
 
     cromwell_stdout = get_abspath(args.cromwell_stdout)
     with open(cromwell_stdout, 'w') as f:
         try:
-            thread = caper_runner.server(fileobj_stdout=f, **kwargs)
+            thread = caper_runner.server(fileobj_stdout=f, **args_from_cli)
             if thread:
                 thread.join()
                 if thread.returncode:

--- a/caper/cli.py
+++ b/caper/cli.py
@@ -30,7 +30,12 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DB_FILE_PREFIX = 'caper_file_db'
 DEFAULT_SERVER_HEARTBEAT_FILE = '~/.caper/default_server_heartbeat'
-USER_INTERRUPT_WARNING = '\n********** DO NOT CTRL+C MULTIPLE TIMES **********\n'
+USER_INTERRUPT_WARNING = (
+    '\n\n'
+    '*** DO NOT CTRL+C MULTIPLE TIMES! ***\n'
+    '*** OR CAPER WILL NOT BE ABLE TO STOP CROMWELL AND RUNNING WORKFLOWS/TASKS ***'
+    '\n\n'
+)
 REGEX_DELIMITER_GCP_PARAMS = r',| '
 PRINT_ROW_DELIMITER = '\t'
 
@@ -327,9 +332,10 @@ def subcmd_server(caper_runner, args, nonblocking=False):
                     logger.error(
                         'Check stdout/stderr in {file}'.format(file=cromwell_stdout)
                     )
+        except KeyboardInterrupt:
+            logger.error(USER_INTERRUPT_WARNING, exc_info=True)
 
-        except Exception:
-            logger.error(USER_INTERRUPT_WARNING)
+        finally:
             if thread:
                 thread.stop()
 
@@ -370,8 +376,10 @@ def subcmd_run(caper_runner, args):
                         'Check stdout/stderr in {file}'.format(file=cromwell_stdout)
                     )
 
-        except Exception:
-            logger.error(USER_INTERRUPT_WARNING)
+        except KeyboardInterrupt:
+            logger.error(USER_INTERRUPT_WARNING, exc_info=True)
+
+        finally:
             if thread:
                 thread.stop()
 

--- a/caper/cromwell.py
+++ b/caper/cromwell.py
@@ -306,7 +306,13 @@ class Cromwell:
                     # to make it a return value of the thread after it is done (joined)
                     return metadata_dict
 
-        th = NBSubprocThread(cmd, cwd=cwd, on_stdout=on_stdout, on_finish=on_finish)
+        th = NBSubprocThread(
+            cmd,
+            cwd=cwd,
+            on_stdout=on_stdout,
+            on_finish=on_finish,
+            subprocess_name='Cromwell',
+        )
         th.start()
 
         return th
@@ -451,7 +457,13 @@ class Cromwell:
             if server_heartbeat:
                 server_heartbeat.stop()
 
-        th = NBSubprocThread(cmd, cwd=cwd, on_stdout=on_stdout, on_finish=on_finish)
+        th = NBSubprocThread(
+            cmd,
+            cwd=cwd,
+            on_stdout=on_stdout,
+            on_finish=on_finish,
+            subprocess_name='Cromwell',
+        )
         th.start()
 
         return th

--- a/caper/cromwell_backend.py
+++ b/caper/cromwell_backend.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from collections import UserDict
 from copy import deepcopy
@@ -305,6 +306,10 @@ class CromwellBackendGCP(CromwellBackendBase):
                     'json-file': gcp_service_account_key_json,
                 }
             ]
+            # parse service account key JSON to get client_email.
+            with open(gcp_service_account_key_json) as fp:
+                key_json = json.loads(fp.read())
+            genomics['compute-service-account'] = key_json['client_email']
         else:
             genomics['auth'] = 'application-default'
             filesystems['gcs']['auth'] = 'application-default'

--- a/caper/cromwell_rest_api.py
+++ b/caper/cromwell_rest_api.py
@@ -9,7 +9,7 @@ from .cromwell_metadata import CromwellMetadata
 logger = logging.getLogger(__name__)
 
 
-def request_error_handler(func):
+def requests_error_handler(func):
     """Re-raise ConnectionError with help message.
     Re-raise from None to hide nested tracebacks.
     """
@@ -297,7 +297,7 @@ class CromwellRestAPI:
         else:
             self._auth = None
 
-    @request_error_handler
+    @requests_error_handler
     def __request_get(self, endpoint, params=None):
         """GET request
 
@@ -314,7 +314,7 @@ class CromwellRestAPI:
         resp.raise_for_status()
         return resp.json()
 
-    @request_error_handler
+    @requests_error_handler
     def __request_post(self, endpoint, manifest=None):
         """POST request
 
@@ -331,7 +331,7 @@ class CromwellRestAPI:
         resp.raise_for_status()
         return resp.json()
 
-    @request_error_handler
+    @requests_error_handler
     def __request_patch(self, endpoint, data):
         """POST request
 

--- a/tests/test_cli_server_client_gcp.py
+++ b/tests/test_cli_server_client_gcp.py
@@ -35,7 +35,6 @@ def test_server_client(
 
     out_gcs_bucket = os.path.join(gcs_root, 'caper_out', ci_prefix)
     tmp_gcs_bucket = os.path.join(gcs_root, 'caper_tmp')
-    os.chdir(str(tmp_path))
 
     cmd = ['server']
     cmd += ['--local-loc-dir', str(tmp_path / 'tmp_dir')]

--- a/tests/test_cli_server_client_gcp.py
+++ b/tests/test_cli_server_client_gcp.py
@@ -35,6 +35,7 @@ def test_server_client(
 
     out_gcs_bucket = os.path.join(gcs_root, 'caper_out', ci_prefix)
     tmp_gcs_bucket = os.path.join(gcs_root, 'caper_tmp')
+    os.chdir(str(tmp_path))
 
     cmd = ['server']
     cmd += ['--local-loc-dir', str(tmp_path / 'tmp_dir')]
@@ -84,6 +85,7 @@ def test_server_client(
         cmd = ['submit', str(wdl)]
         if gcp_service_account_key_json:
             cmd += ['--gcp-service-account-key-json', gcp_service_account_key_json]
+        cmd += ['--port', str(server_port)]
         cmd += ['--inputs', str(inputs)]
         cmd += ['--imports', str(imports)]
         cmd += ['--gcp-zones', 'us-west1-a,us-west1-b']
@@ -109,6 +111,7 @@ def test_server_client(
 
         # unhold it
         cmd = ['unhold', workflow_id]
+        cmd += ['--port', str(server_port)]
         cli_main(cmd)
 
         time.sleep(5)


### PR DESCRIPTION
See https://encodedcc.atlassian.net/browse/PIP-1358 for details.

This PR was originally created to fix service account issue (not using given service account `--gcp-service-account-key-json` for provisioning instances on Google Compute Engine). It was simply fixed by adding a few lines to the backend file (`backend.conf`).
https://github.com/ENCODE-DCC/caper/pull/88/files#diff-5bbfdab5434768780bed99ad70362643R309

However, found a critical hanging issue (related to early closing of file object for logging) so fix for such issue is also included in this PR.

Also improved warning for user interruption (Ctrl + C). 