### PR TITLE
PIP-1336: fix for PBS backend

### DIFF
--- a/caper/cromwell_backend.py
+++ b/caper/cromwell_backend.py
@@ -722,7 +722,7 @@ class CromwellBackendPBS(CromwellBackendLocal):
                     -N ${job_name} \\
                     -o ${out} \\
                     -e ${err} \\
-                    ${true="-lselect=1:ncpus=" false="" defined(cpu)}${cpu}${true=":mem=" false="" defined(memory_mb)}${memory_mb}${true="mb" false="" defined(memory_mb)} \\
+                    ${true="-lnodes=1:ppn=" false="" defined(cpu)}${cpu}${true=":mem=" false="" defined(memory_mb)}${memory_mb}${true="mb" false="" defined(memory_mb)} \\
                     ${'-lwalltime=' + time + ':0:0'} \\
                     ${'-lngpus=' + gpu} \\
                     ${'-q ' + pbs_queue} \\


### PR DESCRIPTION
Fix for PBS (Torque).

TLDR: I just needed to replace `-lselect=1:ncpus=` with `-lnodes=1:ppn=`, which is better for general PBS (Torque) cluster settings.