### PR TITLE
per https://github.com/broadinstitute/cromwell/pull/5468 need to prov…

### DIFF
--- a/caper/cromwell_backend.py
+++ b/caper/cromwell_backend.py
@@ -393,6 +393,7 @@ class CromwellBackendAWS(CromwellBackendBase):
         config['root'] = aws_out_dir
 
         self.default_runtime_attributes['queueArn'] = aws_batch_arn
+        self.default_runtime_attributes['scriptBucketName'] = aws_out_dir.replace('s3://', '')
 
 
 class CromwellBackendLocal(CromwellBackendBase):


### PR DESCRIPTION
…ide scriptBucketName to default-runtime-attributes for aws batch

Seems that AWS batch support broke with this cromwell change - https://github.com/broadinstitute/cromwell/pull/5468