### PR TITLE
Pip 1528 direct read from hocon

### DIFF
--- a/caper/__init__.py
+++ b/caper/__init__.py
@@ -2,4 +2,4 @@ from .caper_client import CaperClient, CaperClientSubmit
 from .caper_runner import CaperRunner
 
 __all__ = ['CaperClient', 'CaperClientSubmit', 'CaperRunner']
-__version__ = '1.5.1'
+__version__ = '1.6.0'

--- a/caper/hocon_string.py
+++ b/caper/hocon_string.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 import re
@@ -10,42 +11,146 @@ logger = logging.getLogger(__name__)
 
 
 NEW_LINE = '\n'
+RE_HOCON_INCLUDE = [
+    r'include\s+(?:required|url|file|classpath)\(.*\)',
+    r'include\s+".*\.(?:conf|hocon)"',
+]
+RE_HOCONSTRING_INCLUDE = r'HOCONSTRING_INCLUDE_(?:.*)\s*=\s*"(?:.*)"'
+RE_HOCONSTRING_INCLUDE_VALUE = r'HOCONSTRING_INCLUDE_(?:.*)\s*=\s*"(.*)"'
+HOCONSTRING_INCLUDE_KEY = 'HOCONSTRING_INCLUDE_{id}'
+
+
+def escape_double_quotes(double_quotes):
+    return double_quotes.replace('"', '\\"')
+
+
+def unescape_double_quotes(escaped_double_quotes):
+    return escaped_double_quotes.replace('\\"', '"')
+
+
+def is_valid_include_key(key):
+    matched = re.findall(RE_HOCONSTRING_INCLUDE, key)
+    return matched and len(matched) == 1
+
+
+def get_include_key(include_str):
+    """Use md5sum hash of the whole include statement string for a key.
+    """
+    return hashlib.md5(include_str.encode()).hexdigest()
+
+
+def wrap_includes(hocon_str):
+    """Convert `include` statement string into key = val format.
+    Returns '{key} = "{double_quote_escaped_val}"'.
+    """
+    for regex in RE_HOCON_INCLUDE:
+        for include in re.findall(regex, hocon_str):
+            if '\\"' in include:
+                continue
+
+            logger.debug('Found include in HOCON: {include}'.format(include=include))
+
+            hocon_str = hocon_str.replace(
+                include,
+                '{key} = "{val}"'.format(
+                    key=HOCONSTRING_INCLUDE_KEY.format(id=get_include_key(include)),
+                    val=escape_double_quotes(include),
+                ),
+            )
+    return hocon_str
+
+
+def unwrap_includes(key_val_str):
+    """Convert '{key} = "{val}"" formatted string to the original `include` statement string.
+    Args:
+        key:
+            HOCONSTRING_INCLUDE_KEY with `id` as md5sum hash of the original
+            `include` statement string.
+        val:
+            Double-quote-escaped `include` statement string.
+    """
+    val = re.findall(RE_HOCONSTRING_INCLUDE_VALUE, key_val_str)
+    if val:
+        if len(val) > 1:
+            raise ValueError(
+                'Found multiple matches. Wrong include key=val format? {val}'.format(
+                    val=val
+                )
+            )
+        return unescape_double_quotes(val[0])
+
+
+def is_valid_include(include):
+    is_valid_format = False
+    for regex in RE_HOCON_INCLUDE:
+        if re.findall(regex, include):
+            is_valid_format = True
+            break
+
+    return is_valid_format
 
 
 class HOCONString:
-    RE_INCLUDE_LINE = r'^\s*include\s'
-
     def __init__(self, hocon_str):
-        """Splits HOCON string into "include" lines and the rest.
-        Ignore "include" lines while parsing it.
-        """
-        lines_include = []
-        lines_wo_include = []
-        for line in hocon_str.splitlines():
-            if re.findall(HOCONString.RE_INCLUDE_LINE, line):
-                lines_include.append(line)
-            else:
-                lines_wo_include.append(line)
+        """Find an `include` statement (VALUE) in HOCON string and then convert it
+        into a HOCONSTRING_INCLUDE_KEY="VALUE" pair in HOCON.
 
-        self._include = NEW_LINE.join(lines_include)
-        self._contents_wo_include = NEW_LINE.join(lines_wo_include)
+        Double-quotes will be escaped with double slashes.
+        Then the VALUE is kept as it is as a value and can be recovered later when
+        it is converted back to HOCON string.
+
+        This workaround is to skip parsing `include` statements since there is no
+        information about `classpath` at the parsing time and pyhocon will error out and
+        will stop parsing.
+
+        e.g. we don't know what's in `classpath` before the backend conf file is
+        passed to Cromwell.
+        """
+        if not isinstance(hocon_str, str):
+            raise ValueError('HOCONString() takes str type only.')
+
+        self._hocon_str = wrap_includes(hocon_str)
 
     def __str__(self):
         return self.get_contents()
 
     @classmethod
     def from_dict(cls, d, include=''):
+        """Create HOCONString from dict.
+
+        Args:
+            include:
+                `include` statement to be added to the top of the HOCONString.
+        """
         hocon = ConfigFactory.from_dict(d)
         hocon_str = HOCONConverter.to_hocon(hocon)
+
         if include:
+            if not is_valid_include(include):
+                raise ValueError(
+                    'Wrong HOCON include format. {include}'.format(include=include)
+                )
             hocon_str = NEW_LINE.join([include, hocon_str])
+
         return cls(hocon_str=hocon_str)
 
-    def to_dict(self):
-        """Convert contents without include to dict.
+    def to_dict(self, with_include=True):
+        """Convert HOCON string into dict.
+
+        Args:
+            with_include:
+                If True then double-quote-escaped `include` statements will be kept as a plain string
+                under key HOCONSTRING_INCLUDE_KEY.
+                Otherwise, `include` statements will be excluded.
         """
-        c = ConfigFactory.parse_string(self._contents_wo_include)
+        if with_include:
+            hocon_str = self._hocon_str
+        else:
+            hocon_str = self.get_contents(with_include=False)
+
+        c = ConfigFactory.parse_string(hocon_str)
         j = HOCONConverter.to_json(c)
+
         return json.loads(j)
 
     def merge(self, b, update=False):
@@ -55,7 +160,7 @@ class HOCONString:
                 HOCONString, dict, str to be merged.
                 b's `include` statement will always be ignored.
             update:
-                If `update` then replace self with a merged one.
+                If True then replace self with a merged one.
         Returns:
             String of merged HOCONs.
         """
@@ -73,17 +178,35 @@ class HOCONString:
 
         hocon = ConfigFactory.from_dict(self_d)
 
-        contents_wo_include = HOCONConverter.to_hocon(hocon)
+        hocon_str = HOCONConverter.to_hocon(hocon)
         if update:
-            self._contents_wo_include = contents_wo_include
+            self._hocon_str = hocon_str
 
-        return NEW_LINE.join([self._include, contents_wo_include])
+        return HOCONString(hocon_str).get_contents()
 
-    def get_include(self):
-        return self._include
+    def get_contents(self, with_include=True):
+        """Check if `include` statement is stored as a plain string.
+        If exists, converts it back to HOCON `include` statement.
 
-    def get_contents(self, without_include=False):
-        if without_include:
-            return self._contents_wo_include
-        else:
-            return NEW_LINE.join([self._include, self._contents_wo_include])
+        Args:
+            with_include: (renamed/changed from without_include)
+                If True then recover all includes statements from include key=val form
+                (RE_HOCONSTRING_INCLUDE).
+                Otherwise, excludes all `include` statements.
+        """
+        hocon_str = self._hocon_str
+
+        for include_key_val in re.findall(RE_HOCONSTRING_INCLUDE, self._hocon_str):
+            logger.debug(
+                'Found include key in HOCONString: {include_key_val}'.format(
+                    include_key_val=include_key_val
+                )
+            )
+            if with_include:
+                original_include_str = unwrap_includes(include_key_val)
+                if original_include_str:
+                    hocon_str = hocon_str.replace(include_key_val, original_include_str)
+            else:
+                hocon_str = hocon_str.replace(include_key_val, '')
+
+        return hocon_str

--- a/caper/hocon_string.py
+++ b/caper/hocon_string.py
@@ -28,9 +28,14 @@ def unescape_double_quotes(escaped_double_quotes):
     return escaped_double_quotes.replace('\\"', '"')
 
 
-def is_valid_include_key(key):
-    matched = re.findall(RE_HOCONSTRING_INCLUDE, key)
-    return matched and len(matched) == 1
+def is_valid_include(include):
+    is_valid_format = False
+    for regex in RE_HOCON_INCLUDE:
+        if re.findall(regex, include):
+            is_valid_format = True
+            break
+
+    return is_valid_format
 
 
 def get_include_key(include_str):
@@ -78,16 +83,6 @@ def unwrap_includes(key_val_str):
                 )
             )
         return unescape_double_quotes(val[0])
-
-
-def is_valid_include(include):
-    is_valid_format = False
-    for regex in RE_HOCON_INCLUDE:
-        if re.findall(regex, include):
-            is_valid_format = True
-            break
-
-    return is_valid_format
 
 
 class HOCONString:

--- a/tests/test_hocon_string.py
+++ b/tests/test_hocon_string.py
@@ -44,10 +44,33 @@ def get_test_hocon_str2():
     return hocon_str2
 
 
-def get_test_dict():
-    """Without "include" lines.
-    """
-    return {
+def get_test_hocon_str_multiple_includes():
+    return dedent(
+        """\
+        include required(classpath("application"))
+        include required(file("application"))
+        include required(url("application"))
+        include required("application.conf")
+        level1 {
+          include file("/srv/test.conf")
+          level2 {
+            include url("http://ok.com/test.conf")
+            level3 {
+              include classpath("test")
+              level4 {
+                include "test.conf"
+                level5 {
+                  include "test.hocon"
+                }
+              }
+            }
+          }
+        }"""
+    )
+
+
+def get_test_dict(with_include=False):
+    base_dict = {
         'backend': {
             'default': 'gcp',
             'providers': {
@@ -61,12 +84,45 @@ def get_test_dict():
             },
         }
     }
+    if with_include:
+        base_dict[
+            'HOCONSTRING_INCLUDE_ad5c3c187d5107c099f66681f1896c70'
+        ] = 'include required(classpath("application"))'
+
+    return base_dict
 
 
 def get_test_dict2():
     """Without "include" lines.
     """
     return {'backend': {'providers': {'gcp': {'actor-factory': 'GOOGLE'}}}}
+
+
+def get_test_multiple_includes(with_include=False):
+    if with_include:
+        return {
+            "HOCONSTRING_INCLUDE_ad5c3c187d5107c099f66681f1896c70": "include required(classpath(\"application\"))",
+            "HOCONSTRING_INCLUDE_61b86ce2e19939719a2e043b923774e4": "include required(file(\"application\"))",
+            "HOCONSTRING_INCLUDE_543d042c69d8a730bc2b5785ac2f13c9": "include required(url(\"application\"))",
+            "HOCONSTRING_INCLUDE_9456b859a44adad9a3d00ff3fcbbc5ae": "include required(\"application.conf\")",
+            "level1": {
+                "HOCONSTRING_INCLUDE_0714deb341d3d6291199d4738656c32b": "include file(\"/srv/test.conf\")",
+                "level2": {
+                    "HOCONSTRING_INCLUDE_91f31b362d72089d09f6245e912efb30": "include url(\"http://ok.com/test.conf\")",
+                    "level3": {
+                        "HOCONSTRING_INCLUDE_906d6e6eff885e840b705c2e7be3ba2d": "include classpath(\"test\")",
+                        "level4": {
+                            "HOCONSTRING_INCLUDE_c971be2dbb00ef0b44b9e4bf3c57f5cb": "include \"test.conf\"",
+                            "level5": {
+                                "HOCONSTRING_INCLUDE_44cb98470497b76dde0ab244c70870f0": "include \"test.hocon\""
+                            },
+                        },
+                    },
+                },
+            },
+        }
+    else:
+        return {'level1': {'level2': {'level3': {'level4': {'level5': {}}}}}}
 
 
 def test_from_dict():
@@ -79,47 +135,60 @@ def test_from_dict():
 
 def test_to_dict():
     hs = HOCONString(get_test_hocon_str())
-    assert hs.to_dict() == get_test_dict()
+    assert hs.to_dict(with_include=False) == get_test_dict(with_include=False)
+    assert hs.to_dict(with_include=True) == get_test_dict(with_include=True)
+
+    hs = HOCONString(get_test_hocon_str_multiple_includes())
+    assert hs.to_dict(with_include=False) == get_test_multiple_includes(
+        with_include=False
+    )
+    assert hs.to_dict(with_include=True) == get_test_multiple_includes(
+        with_include=True
+    )
 
 
 def test_merge():
     s1 = get_test_hocon_str()
     s2 = get_test_hocon_str2()
+    s3 = get_test_hocon_str_multiple_includes()
 
     d1 = get_test_dict()
     d2 = get_test_dict2()
-    dm = deepcopy(d1)
-    merge_dict(dm, d2)
+    d3 = get_test_multiple_includes(True)
+
+    dm12 = deepcopy(d1)
+    merge_dict(dm12, d2)
+    dm32 = deepcopy(d3)
+    merge_dict(dm32, d2)
 
     hs1 = HOCONString(s1)
     hs2 = HOCONString(s2)
-    hsm = HOCONString.from_dict(dm, include=INCLUDE_CROMWELL)
+    hs3 = HOCONString(s3)
+    hsm12 = HOCONString.from_dict(dm12, include=INCLUDE_CROMWELL)
+    hsm32 = HOCONString.from_dict(dm32)
 
-    assert str(hsm) == hs1.merge(hs2)
-    assert str(hsm) == hs1.merge(d2)
-    assert str(hsm) == hs1.merge(s2)
+    assert str(hsm12) == hs1.merge(hs2)
+    assert str(hsm12) == hs1.merge(d2)
+    assert str(hsm12) == hs1.merge(s2)
+
+    assert str(hsm32) == hs3.merge(hs2)
+    assert str(hsm32) == hs3.merge(d2)
+    assert str(hsm32) == hs3.merge(s2)
 
     # merge with update
     # item 1 should be updated with merged
     hs1_original_str = str(hs1)
-    assert str(hsm) == hs1.merge(hs2, update=True)
-    assert str(hs1) == str(hsm)
+    assert str(hsm12) == hs1.merge(hs2, update=True)
+    assert str(hs1) == str(hsm12)
     assert hs1_original_str != str(hs1)
-
-
-def test_get_include():
-    s2 = get_test_hocon_str2()
-    hs2 = HOCONString(s2)
-
-    assert hs2.get_include() == INCLUDE_CROMWELL
 
 
 def test_get_contents():
     s2 = get_test_hocon_str2()
     hs2 = HOCONString(s2)
 
-    c2 = hs2.get_contents(without_include=False)
-    assert c2 == s2
-
-    c2_wo_i = hs2.get_contents(without_include=True)
-    assert c2_wo_i == s2.replace(INCLUDE_CROMWELL + '\n', '')
+    assert hs2.get_contents(with_include=True).strip() == s2
+    assert (
+        hs2.get_contents(with_include=False).strip()
+        == s2.replace(INCLUDE_CROMWELL, '').strip()
+    )


### PR DESCRIPTION
Cromwell is based on Java and `pyhocon` always fails due to `include classpath()` defined at the top of the conf file.
Avoid `pyhocon`'s parsing error by wrapping `include` statements in HOCON to a `key="val"` form and then unwrap it back later.