### PR TITLE
Modified cromwell for aws backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ install_python3: &install_python3_java
 install_singularity: &install_singularity
   name: Install Singularity (container)
   command: |
-    sudo wget -O- http://neuro.debian.net/lists/xenial.us-ca.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
+    sudo wget -O- https://neuro.debian.net/lists/focal.us-ca.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
     # key server is so unstable. commented out for possible later use.
     #sudo apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9
     sudo apt-get update && sudo apt-get install singularity-container --allow-unauthenticated

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,16 +22,12 @@ update_apt: &update_apt
 install_python3: &install_python3_java
   name: Install python3, pip3, java11
   command: |
-    sudo apt-get install software-properties-common git wget curl -y
+    sudo apt-get install software-properties-common git wget curl openjdk-11-jdk -y
     sudo add-apt-repository ppa:deadsnakes/ppa -y
     sudo apt-get update && sudo apt-get install python3.6 -y
     sudo wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py
     sudo python3.6 get-pip.py
     sudo ln -s /usr/bin/python3.6 /usr/local/bin/python3
-
-    sudo add-apt-repository ppa:linuxuprising/java
-    sudo apt-get update && sudo apt-get install oracle-java11-installer
-    sudo apt-get install oracle-java11-set-default
 
 
 install_singularity: &install_singularity

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,8 @@ update_apt: &update_apt
     sudo apt-get update
 
 
-install_python3: &install_python3_java
-  name: Install python3, pip3, java (openjdk-11)
+install_python3: &install_python3
+  name: Install python3, pip3
   command: |
     sudo apt-get install software-properties-common git wget curl -y
     sudo add-apt-repository ppa:deadsnakes/ppa -y
@@ -28,9 +28,6 @@ install_python3: &install_python3_java
     sudo wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py
     sudo python3.6 get-pip.py
     sudo ln -s /usr/bin/python3.6 /usr/local/bin/python3
-
-    sudo add-apt-repository ppa:openjdk-r/ppa -y
-    sudo apt-get update && sudo apt-get install openjdk-11-jdk -y
 
 
 install_singularity: &install_singularity
@@ -64,17 +61,26 @@ install_aws_lib: &install_aws_lib
     sudo pip3 install boto3 awscli
 
 
+install_java: &install_java
+  name: Install openjdk-11
+  command: |
+    sudo add-apt-repository ppa:openjdk-r/ppa -y
+    sudo apt-get update && sudo apt-get install openjdk-11-jdk -y
+    # automatically set 11 as default java
+    sudo update-java-alternatives -a
+
 jobs:
   pytest:
     <<: *machine_defaults
     steps:
       - checkout
       - run: *update_apt
-      - run: *install_python3_java
+      - run: *install_python3
       - run: *install_singularity
       - run: *install_py3_packages
       - run: *install_gcs_lib
       - run: *install_aws_lib
+      - run: *install_java
       - run:
           no_output_timeout: 60m
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults:
 
 machine_defaults: &machine_defaults
   machine:
-    image: ubuntu-1604:202007-01
+    image: ubuntu-2004:202104-01
   working_directory: ~/caper
 
 
@@ -23,11 +23,6 @@ install_python3: &install_python3_java
   name: Install python3, pip3, java
   command: |
     sudo apt-get install software-properties-common git wget curl default-jre -y
-    sudo add-apt-repository ppa:deadsnakes/ppa -y
-    sudo apt-get update && sudo apt-get install python3.6 -y
-    sudo wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py
-    sudo python3.6 get-pip.py
-    sudo ln -s /usr/bin/python3.6 /usr/local/bin/python3
 
 
 install_singularity: &install_singularity

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ update_apt: &update_apt
 install_python3: &install_python3_java
   name: Install python3, pip3, java11
   command: |
+    sudo apt-get purge default-jdk openjdk-8-jdk -y
     sudo apt-get install software-properties-common git wget curl openjdk-11-jdk -y
     sudo add-apt-repository ppa:deadsnakes/ppa -y
     sudo apt-get update && sudo apt-get install python3.6 -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults:
 
 machine_defaults: &machine_defaults
   machine:
-    image: ubuntu-2004:202104-01
+    image: ubuntu-1604:202007-01
   working_directory: ~/caper
 
 
@@ -20,18 +20,27 @@ update_apt: &update_apt
 
 
 install_python3: &install_python3_java
-  name: Install python3, pip3, java
+  name: Install python3, pip3, java11
   command: |
-    sudo apt-get install software-properties-common git wget curl default-jre -y
+    sudo apt-get install software-properties-common git wget curl -y
+    sudo add-apt-repository ppa:deadsnakes/ppa -y
+    sudo apt-get update && sudo apt-get install python3.6 -y
+    sudo wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py
+    sudo python3.6 get-pip.py
+    sudo ln -s /usr/bin/python3.6 /usr/local/bin/python3
+
+    sudo add-apt-repository ppa:linuxuprising/java
+    sudo apt-get update && sudo apt-get install oracle-java11-installer
+    sudo apt-get install oracle-java11-set-default
 
 
 install_singularity: &install_singularity
   name: Install Singularity (container)
   command: |
-    sudo wget -O- https://neuro.debian.net/lists/focal.us-ca.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
+    sudo wget -O- http://neuro.debian.net/lists/xenial.us-ca.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
     # key server is so unstable. commented out for possible later use.
-    sudo apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9
-    sudo apt-get update && sudo apt-get install singularity-container #--allow-unauthenticated
+    #sudo apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9
+    sudo apt-get update && sudo apt-get install singularity-container --allow-unauthenticated
 
 
 install_py3_packages: &install_py3_packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,15 +20,17 @@ update_apt: &update_apt
 
 
 install_python3: &install_python3_java
-  name: Install python3, pip3, java11
+  name: Install python3, pip3, java (openjdk-11)
   command: |
-    sudo apt-get purge default-jdk openjdk-8-jdk -y
-    sudo apt-get install software-properties-common git wget curl openjdk-11-jdk -y
+    sudo apt-get install software-properties-common git wget curl -y
     sudo add-apt-repository ppa:deadsnakes/ppa -y
     sudo apt-get update && sudo apt-get install python3.6 -y
     sudo wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py
     sudo python3.6 get-pip.py
     sudo ln -s /usr/bin/python3.6 /usr/local/bin/python3
+
+    sudo add-apt-repository ppa:openjdk-r/ppa -y
+    sudo apt-get update && sudo apt-get install openjdk-11-jdk -y
 
 
 install_singularity: &install_singularity

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ install_singularity: &install_singularity
   command: |
     sudo wget -O- https://neuro.debian.net/lists/focal.us-ca.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
     # key server is so unstable. commented out for possible later use.
-    #sudo apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9
-    sudo apt-get update && sudo apt-get install singularity-container --allow-unauthenticated
+    sudo apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9
+    sudo apt-get update && sudo apt-get install singularity-container #--allow-unauthenticated
 
 
 install_py3_packages: &install_py3_packages

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and 
 
 ## Installation
 
-1) Make sure that you have Java (>= 1.8) installed on your system.
+1) Make sure that you have Java (>= 11) installed on your system.
 
 	```bash
 	$ java -version

--- a/caper/__init__.py
+++ b/caper/__init__.py
@@ -2,4 +2,4 @@ from .caper_client import CaperClient, CaperClientSubmit
 from .caper_runner import CaperRunner
 
 __all__ = ['CaperClient', 'CaperClientSubmit', 'CaperRunner']
-__version__ = '1.6.3'
+__version__ = '1.6.4'

--- a/caper/caper_init.py
+++ b/caper/caper_init.py
@@ -108,6 +108,14 @@ backend=aws
 aws-batch-arn=
 aws-region=
 aws-out-dir=
+
+# use this modified cromwell to fix input file localization failures
+# (104 Connection reset by peer)
+# cromwell uses AWS CLI(aws s3 cp)'s native retry feature which is controlled by
+# several environment variables but it doesn't seem to work for some reason
+# this is an adhoc fix to make cromwell retry up to 5 times in the bash script level
+# https://github.com/ENCODE-DCC/cromwell/commit/d16af26483e0019e14d6f8b158eaf64529f57d98
+cromwell=https://storage.googleapis.com/caper-data/cromwell/cromwell-65-d16af26-SNAP.jar
 """
     + CONF_CONTENTS_TMP_DIR
 )

--- a/caper/cromwell.py
+++ b/caper/cromwell.py
@@ -37,9 +37,9 @@ class Cromwell:
     """Wraps Cromwell/Womtool.
     """
 
-    DEFAULT_CROMWELL = 'https://github.com/broadinstitute/cromwell/releases/download/59/cromwell-59.jar'
+    DEFAULT_CROMWELL = 'https://github.com/broadinstitute/cromwell/releases/download/65/cromwell-65.jar'
     DEFAULT_WOMTOOL = (
-        'https://github.com/broadinstitute/cromwell/releases/download/59/womtool-59.jar'
+        'https://github.com/broadinstitute/cromwell/releases/download/65/womtool-65.jar'
     )
     DEFAULT_CROMWELL_INSTALL_DIR = '~/.caper/cromwell_jar'
     DEFAULT_WOMTOOL_INSTALL_DIR = '~/.caper/womtool_jar'

--- a/scripts/aws_caper_server/create_instance.sh
+++ b/scripts/aws_caper_server/create_instance.sh
@@ -224,6 +224,7 @@ aws-batch-arn=$AWS_BATCH_ARN
 aws-region=$AWS_REGION
 aws-out-dir=$AWS_OUT_DIR
 aws-loc-dir=$AWS_LOC_DIR
+cromwell=https://storage.googleapis.com/caper-data/cromwell/cromwell-65-d16af26-SNAP.jar
 # metadata DB
 db=postgresql
 postgresql-db-ip=$POSTGRESQL_DB_IP


### PR DESCRIPTION
upgraded cromwell from 59 to 65
- no metadata DB compatibility issues between two
- 65 requires java>=11, there were some installation issues in circleci testing due to the change of Java licensing policy. all fixed now.

cromwell-65 is a forked/modified one to fix AWS backend issues
- localization fails when the output bucket is busy. cromwell's retrial is buggy.
- https://github.com/ENCODE-DCC/cromwell/tree/caper
