### PR TITLE
Pip 1626 docker and conda in task runtime

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -457,3 +457,380 @@ Example:
 	```bash
 	$ aws configure
 	```
+
+
+
+## How to override Caper's built-in backend
+
+If Caper's built-in backends don't work as expected on your clusters (e.g. due to different resource settings), then you can override built-in backends with your own configuration file (e.g. `your.backend.conf`). Caper generates a `backend.conf` for built-in backends on a temporary directory.
+
+Find this `backend.conf` first by dry-running `caper run [WDL] --dry-run ...`. For example of a `slurm` backend:
+```
+$ caper run main.wdl --dry-run
+2020-07-07 11:18:13,196|caper.caper_runner|INFO| Adding encode-dcc-1016 to env var GOOGLE_CLOUD_PROJECT
+2020-07-07 11:18:13,197|caper.caper_base|INFO| Creating a timestamped temporary directory. /mnt/data/scratch/leepc12/test_caper_tmp/main/20200707_111813_197082
+2020-07-07 11:18:13,197|caper.caper_runner|INFO| Localizing files on work_dir. /mnt/data/scratch/leepc12/test_caper_tmp/main/20200707_111813_197082
+2020-07-07 11:18:13,829|caper.cromwell|INFO| Validating WDL/inputs/imports with Womtool...
+2020-07-07 11:18:16,034|caper.cromwell|INFO| Womtool validation passed.
+2020-07-07 11:18:16,035|caper.caper_runner|INFO| launching run: wdl=/mnt/data2/scratch/leepc12/test_wdl1_sub/main.wdl, inputs=None, backend_conf=/mnt/data/scratch/leepc12/test_caper_tmp/main/20200707_111813_197082/backend.conf
+```
+
+Find `backend_conf`, make a copy of it and edit it.
+
+```
+include required(classpath("application"))
+backend {
+  default = "slurm"
+  providers {
+
+  ...
+
+    slurm {
+      config {
+        default-runtime-attributes {
+          time = 24
+        }
+        concurrent-job-limit = 1000
+        script-epilogue = "sleep 10 && sync"
+        filesystems {
+          local {
+            localization = [
+              "soft-link"
+              "hard-link"
+              "copy"
+            ]
+            caching {
+              check-sibling-md5 = true
+              duplication-strategy = [
+                "soft-link"
+                "hard-link"
+                "copy"
+              ]
+              hashing-strategy = "path+modtime"
+            }
+          }
+        }
+        run-in-background = true
+        runtime-attributes = """String? docker
+String? docker_user
+Int cpu = 1
+Int? gpu
+Int? time
+Int? memory_mb
+String? slurm_partition
+String? slurm_account
+String? slurm_extra_param
+String? singularity
+String? singularity_bindpath
+String? singularity_cachedir
+"""
+        submit = """if [ -z \"$SINGULARITY_BINDPATH\" ]; then export SINGULARITY_BINDPATH=${singularity_bindpath}; fi; \
+if [ -z \"$SINGULARITY_CACHEDIR\" ]; then export SINGULARITY_CACHEDIR=${singularity_cachedir}; fi;
+
+ITER=0
+until [ $ITER -ge 3 ]; do
+    sbatch \
+        --export=ALL \
+        -J ${job_name} \
+        -D ${cwd} \
+        -o ${out} \
+        -e ${err} \
+        ${'-t ' + time*60} \
+        -n 1 \
+        --ntasks-per-node=1 \
+        ${'--cpus-per-task=' + cpu} \
+        ${true="--mem=" false="" defined(memory_mb)}${memory_mb} \
+        ${'-p ' + slurm_partition} \
+        ${'--account ' + slurm_account} \
+        ${'--gres gpu:' + gpu} \
+        ${slurm_extra_param} \
+        --wrap "${if !defined(singularity) then '/bin/bash ' + script
+                  else
+                    'singularity exec --cleanenv ' +
+                    '--home ' + cwd + ' ' +
+                    (if defined(gpu) then '--nv ' else '') +
+                    singularity + ' /bin/bash ' + script}" \
+        && break
+    ITER=$[$ITER+1]
+    sleep 30
+done
+"""
+        root = "/mnt/data/scratch/leepc12/caper_out"
+        exit-code-timeout-seconds = 360
+        check-alive = """for ITER in 1 2 3; do
+    CHK_ALIVE=$(squeue --noheader -j ${job_id} --format=%i | grep ${job_id})
+    if [ -z "$CHK_ALIVE" ]; then if [ "$ITER" == 3 ]; then /bin/bash -c 'exit 1'; else sleep 30; fi; else echo $CHK_ALIVE; break; fi
+done
+"""
+        kill = "scancel ${job_id}"
+        job-id-regex = "Submitted batch job (\\d+).*"
+      }
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+    }
+  ...
+
+}
+
+...
+
+````
+
+Some part of the script (wrapped in `${}`) is written in WDL. For example, `${true="--mem=" false="" defined(memory_mb)}`, if `memory_mb` is defined it will print `--mem`). For such WDL expressions, you can use any variables defined in `runtime-attributes`.
+
+For example, if your cluster does not allow importing all environment variables (`sbatch --export=ALL` ...)  then you can remove `--export=ALL` from the above script.
+
+There is a retrial logic implemented in this SLURM backend. It retries submitting up to 3 times for some SLURM clusters.
+```
+ITER=0; until [ $ITER -ge 3 ]; do
+...
+ITER=$[$ITER+1]; sleep 30; done
+```
+
+Also, there is another logic to use Singularity. If `singularity` is not given, then Cromwell will run `/bin/bash ${script}` otherwise this backend will collect some Singularity specific environment variables and finally run `singularity exec --cleanenv --home ${cwd} ${singularity} /bin/bash ${script}`. `${singularity}` is a variable that has singularity image location defined in `runtime-attributes` mentioned above.
+```
+sbatch ... --wrap "${if defined(singularity) then '' else '/bin/bash ${script} #`} ..."
+```
+
+There are some built-in variables (`out`, `err`, `cwd`, `script`, `cpu`, `memory_mb` and `time`) in Cromwell, which are important to keep Cromwell's task running. For example, if you remove `-o ${out}` from the script and Cromwell will fail to find `stdout` on output directory, which will lead to a pipeline failure.
+
+See more [details](https://cromwell.readthedocs.io/en/stable/Configuring/) about a backend configuration file.
+
+Your custom `your.backend.conf` file will override on Caper's existing built-in backend, so keep modified parts (`submit` command line in this example) only in your `your.backend.conf` file.
+```
+backend {
+  default = "slurm"
+  providers {
+    slurm {
+        submit = """sbatch         --export=ALL         -J ${job_name}         -D ${cwd}         -o ${out}         -e ${err}         ${"-t " + time*60}         -n 1         --ntasks-per-node=1         ${true="--cpus-per-task=" false="" defined(cpu)}${cpu}         ${true="--mem=" false="" defined(memory_mb)}${memory_mb}         ${"-p " + slurm_partition}         ${"--account " + slurm_account}         ${true="--gres gpu:" false="" defined(gpu)}${gpu}         ${slurm_extra_param}         --wrap "${if defined(singularity) then '' else             '/bin/bash ${script} #'}             if [ -z \"$SINGULARITY_BINDPATH\" ]; then             export SINGULARITY_BINDPATH=${singularity_bindpath}; fi;             if [ -z \"$SINGULARITY_CACHEDIR\" ]; then             export SINGULARITY_CACHEDIR=${singularity_cachedir}; fi;             singularity exec --cleanenv --home ${cwd}             ${if defined(gpu) then '--nv' else ''}             ${singularity} /bin/bash ${script}" && break
+    ITER=$[$ITER+1]; sleep 30; done
+    """
+    }
+  }
+}
+```
+
+And then run `caper run` with your `your.backend.conf`.
+```
+$ caper run ... --backend-file your.backend.conf
+```
+
+
+## Caper server heartbeat (running multiple servers)
+
+Caper server writes a heartbeat file (specified by `--server-heartbeat-file`) on every 120 seconds (controlled by `--server-heartbeat-timeout`). This file will contain an IP(hostname)/PORT pair of the running `caper server`.
+
+Example heartbeat file:
+```bash
+$ cat ~/.caper/default_server_heartbeat
+your.hostname.com:8000
+```
+
+This heartbeat file is useful when users don't want to find IP(hostname)/PORT of a running `caper server` especially when they `qsub`bed or `sbatch`ed `caper server` on their clusters. For such cases, IP (hostname of node/instance) of the server is later determined after the cluster engine starts the submitted `caper server` job and it's inconvenient for the users to find the IP (hostname) of the running server manually with `qstat` or `squeue` and add it back to Caper's configuration file `~/.caper/default.conf`.
+
+Therefore, Caper defaults to use this heartbeat file (can be disabled by a flag `--no-server-heartbeat`). So if client-side caper functions like `caper list` and `caper metadata` finds this heartbeat file and automatically parse it to get an IP/PORT pair.
+
+However, there can be a conflict if users want to run multiple `caper server`s on the same machine (or multiple machines sharing the same caper configuration directory `~/.caper/` and hence the same default heartbeat file). For such cases, users can disable this heartbeat feature by adding the following line to their configuration file: e.g. `~/.caper/default.conf`.
+```bash
+no-server-heartbeat=True
+```
+
+Then start multiple servers with different port and DB (for example of MySQL). Users should make sure that each server uses a different DB (file or MySQL server port, whatever...) since there is no point of using multiple Caper servers with the same DB. For example of MySQL, users should not forget to spin up multiple MySQL servers with different ports.
+
+```bash
+$ caper server --port 8000 --mysql-db-port 3306 ... &
+$ caper server --port 8001 --mysql-db-port 3307 ... &
+$ caper server --port 8002 --mysql-db-port 3308 ... &
+```
+
+Send queries to a specific server.
+```bash
+$ caper list --port 8000
+$ caper list --port 8001
+$ caper list --port 8002
+```
+
+## Metadata database
+
+If you are not interested in resuming failed workflows skip this section.
+
+Cromwell metadata DB is used for call-caching (re-using outputs from previous workflows). Caper>=0.6 defaults to use `in-memory` DB, whose metadata will be all lost when the Caper process stops.
+
+In order to use call-caching, choose one of the following metadata database types with `--db` or `db=` in your Caper conf file `~/.caper/default.conf`.
+
+1) `mysql` (**RECOMMENDED**): We provide [shell scripts](#mysql-server) to run a MySQL server without root. You need either Docker or Singularity installed on your system.
+
+2) `postgresql` (experimental): We don't provide a method to run PostgreSQL server and initialize it correctly for Crowmell. See [this](https://cromwell.readthedocs.io/en/stable/Configuring/) for details.
+
+3) `file` (**UNSTABLE**, not recommended): This is Cromwell's built-in [HyperSQL DB file mode](#file-database). Caper<0.6 defaulted to use it but a file DB turns out to be very unstable and get corrupted easily.
+
+## MySQL database
+
+We provide [shell scripts](bin/run_mysql_server_docker.sh) to run a MySQL server in a container with docker/singularity. Once you have a running MySQL server, add the followings to Caper's conf file `~/.caper/default.conf`. You may need to change the port number if it conflicts.
+
+```
+db=mysql
+mysql-db-port=3306
+```
+
+1) docker
+
+	Ask your admin to add you to the `docker` group or if you are root then install Docker, create a group `docker` and add yourself to the group `docker`.
+
+	```bash
+	$ sudo apt-get install docker.io
+	$ sudo groupadd docker
+	$ sudo usermod -aG docker $USER
+	```
+
+	**RE-LOGIN** and check if Docker `hello-world` works.
+
+	```bash
+	$ docker run hello-world
+	```
+
+	Run the following command line. `PORT` and `CONTAINER_NAME` are optional. MySQL server will run in background.
+
+	```bash
+	$ run_mysql_server_docker.sh [DB_DIR] [PORT]
+	```
+
+	If you see any conflict in `PORT` or `CONTAINER_NAME`, then try with higher `PORT` or different `CONTAINER_NAME` (`mysql_cromwell` by default).
+
+	Example conflict in `PORT`. Try with `3307` or higher.
+	```
+	[PORT] (3306) already taken.
+	```
+
+	Example conflict in `CONTAINER_NAME`. Try with `mysql_cromwell2`.
+	```bash
+	docker: Error response from daemon: Conflict. The container name "/mysql_cromwell" is already in use by container 0584ec7affed0555a4ecbd2ed86a345c542b3c60993960408e72e6ea803cb97e. You have to remove (or rename) that container to be able to reuse that name..
+	```
+
+	Check if MySQL server is running.
+	```bash
+	$ docker ps  # find your MySQL docker container
+	```
+
+	To stop/kill a running MySQL server,
+	```bash
+	$ docker stop [CONTAINER_NAME]  # you can also use a container ID found in the above cmd
+	```
+
+	If you see the following authentication error:
+	```bash
+	Caused by: java.sql.SQLException: Access denied for user 'cromwell'@'localhost' (using password: YES)
+	```
+
+	Then try to remove a volume for MySQL's docker container. See [this](https://github.com/docker-library/mariadb/issues/62#issuecomment-366933805) for details.
+	```bash
+	$ docker volume ls  # find [VOLUME_ID] for your container
+	$ docker volume rm [VOLUME_ID]
+	```
+
+2) Singularity
+
+	Run the following command line. `PORT` and `CONTAINER_NAME` are optional. MySQL server will run in background as a Singularity instance.
+
+	```bash
+	$ run_mysql_server_singularity.sh [DB_DIR] [PORT] [CONTAINER_NAME]
+	```
+
+	If you see any conflict in `PORT` or `CONTAINER_NAME`, then try with higher `PORT` or different `CONTAINER_NAME` (`mysql_cromwell` by default).
+
+	Example conflict in `PORT`. Try with `3307` or higher.
+	```
+	[PORT] (3306) already taken.
+	```
+
+	Example conflict in `CONTAINER_NAME`. Try with `mysql_cromwell2`.
+	```
+	ERROR: A daemon process is already running with this name: mysql_cromwell
+	ABORT: Aborting with RETVAL=255
+	```
+
+	To stop/kill a running MySQL server.
+	```bash
+	$ singularity instance list  # find your MySQL singularity container
+	$ singularity instance stop [CONTAINER_NAME]
+	```
+
+## PostgreSQL database
+
+Add the followings to Caper's conf file `~/.caper/default.conf`. You may need to change the port number if it conflicts.
+```
+db=postgresql
+postgresql-db-port=5432
+```
+
+You do not need superuser privilege to make your own database once you have PostgreSQL installed on your system. Ask your admin to install it.
+
+Make sure to match `DB_PORT`, `DB_NAME`, `DB_USER` and `DB_PASSWORD` with Caper's parameters `--postgresql-db-port`, `--postgresql-db-name`, `--postgresql-db-user`, and `--postgresql-db-password`. You can also define them in  `~/.caper/default.conf`.
+
+```bash
+# make sure to match those variables with corresponding Caper's parameters.
+$ DB_PORT=5432
+$ DB_NAME=cromwell
+$ DB_USER=cromwell
+$ DB_PASSWORD=cromwell
+
+# initialize PostgreSQL server with a specific data path
+# actual data will be stored on directory $DB_FILE_PATH
+$ DB_FILE_PATH=my_postgres
+$ initdb -D $DB_FILE_PATH -U $USER
+
+# start PostgreSQL server with a specific port
+$ DB_LOG_FILE=pg.log
+$ pg_ctl -D $DB_FILE_PATH -o "-F -p $DB_PORT" -l $DB_LOG_FILE start
+
+# create DB for Cromwell
+$ createdb $DB_NAME
+
+# add extension for Cromwell
+$ psql -d $DB_NAME -c "create extension lo;"
+
+# make a role (user)
+$ psql -d $DB_NAME -c "create role $DB_USER with superuser login password $DB_PASSWORD"
+```
+
+
+## File database
+
+> **WARINING**: Using this type of metadata database is **NOT RECOMMENDED**. It's unstable and fragile.
+
+Define file DB parameters in `~/.caper/default.conf`.
+
+```
+db=file
+file-db=/YOUR/FILE/DB/PATH/PREFIX
+```
+
+This file DB is genereted on your working directory by default. Its default filename prefix is `caper_file_db.[INPUT_JSON_BASENAME_WO_EXT]`. A DB is consist of multiple files and directories with the same filename prefix.
+
+Unless you explicitly define `file-db` in your configuration file `~/.caper/default.conf` this file DB name will depend on your input JSON filename. Therefore, you can simply resume a failed workflow with the same command line used for starting a new pipeline.
+
+
+
+
+
+## Profiling/monitoring resources on Google Cloud
+
+A workflow ran with Caper>=1.2.0 on `gcp` backend has a monitoring log (`monitoring.log`) by default on each task's execution directory. This log file includes useful resources data on an instance like used memory, used disk space and total cpu percentage.
+
+`caper gcp_monitor` recursively parses such monitoring log files and show statistics of them in a tab-separated table. `caper gcp_monitor` can take `metadata.json` file URI or a workflow ID if there is a running `caper server`. `--json-format` is optional to print out detailed outputs in a JSON format.
+
+```bash
+$ caper gcp_monitor METADATA_JSON_FILE_OR_WORKFLOW_ID ... --json-format
+```
+
+For further analysis on resource data, use `caper gcp_res_analysis`. `--plot-pdf` is optional to make a multipage PDF file with scatter plots.
+```bash
+$ caper gcp_res_analysis METADATA_JSON_FILE_OR_WORKFLOW_ID ... --plot-pdf [PLOT_PDF_PATH]
+```
+
+Define task's input file variables to limit analysis on specific tasks and input variables. Use `--in-file-vars-def-json` to define it.
+ Example JSON files can be found at the following URLs:
+- ENCODE ATAC-seq pipeline: [Result JSON](https://storage.googleapis.com/caper-data/gcp_resource_analysis/in_file_vars_json/atac.json)
+- ENCODE ChIP-seq pipeline: [Result JSON](https://storage.googleapis.com/caper-data/gcp_resource_analysis/in_file_vars_json/chip.json)
+
+Example plots:
+- ENCODE ATAC-seq pipeline: [Plot PDF](https://storage.googleapis.com/caper-data/gcp_resource_analysis/example_plot/atac.pdf)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Caper (Cromwell Assisted Pipeline ExecutoR) is a wrapper Python package for [Cro
 
 ## Introduction
 
-Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and provides easier way of running Cromwell server/run modes by automatically composing necessary input files for Cromwell. Also, Caper supports easy automatic file transfer between local/cloud storages (local path, `s3://`, `gs://` and `http(s)://`). You can use these URIs in input JSON file or for a WDL file itself.
+Caper wraps Cromwell to run pipelines on multiple platforms like GCP (Google Cloud Platform), AWS (Amazon Web Service) and HPCs like SLURM, SGE, PBS/Torque and LSF. It provides easier way of running Cromwell server/run modes by automatically composing necessary input files for Cromwell. Also, Caper can run each task on a specified environment (Docker, Singularity or Conda). Caper automatically localizes all files defined in your input JSON according to the specified backend. For example, if your chosen backend is GCP and files in your input JSON are on S3 buckets (or even URLs) then Caper automatically transfers `s3://` and `http(s)://` files to a specified `gs://` bucket directory. Supported URIs are `s3://`, `gs://`, `http(s)://` and local absolute paths. Private URIs are also accessible if you authenticate using cloud platform CLIs like `gcloud auth`, `aws configure` and using `~/.netrc` for URLs.
 
 ## Installation
 
@@ -32,7 +32,7 @@ Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and 
 3) Test-run Caper.
 
 	```bash
-	$ caper
+	$ caper -v
 	```
 
 4) If you see an error message like `caper: command not found` then add the following line to the bottom of `~/.bashrc` and re-login.
@@ -53,31 +53,13 @@ Caper is based on Unix and cloud platform CLIs (`curl`, `gsutil` and `aws`) and 
 	slurm | HPC with SLURM cluster engine.
 	sge | HPC with Sun GridEngine cluster engine.
 	pbs | HPC with PBS cluster engine.
-	gcp | Google Cloud Platform.
-	aws | Amazon Web Service.
+  lsf | HPC with LSF cluster engine.
 	sherlock | Stanford Sherlock (based on `slurm` backend).
 	scg | Stanford SCG (based on `slurm` backend).
+  gcp | Google Cloud Platform. See scripts/gcp_caper_server/README.md instead of running `caper init gcp`.
+  aws | Amazon Web Service. See scripts/aws_caper_server/README.md instead of running `caper init aws`.
 
-6) Edit `~/.caper/default.conf`. Find instruction for each parameter in the following table.
-	> **IMPORTANT**: DO NOT LEAVE ANY PARAMETERS UNDEFINED OR CAPER WILL NOT WORK CORRECTLY.
-
-	**Parameter**|**Description**
-	:--------|:-----
-	local-loc-dir | **IMPORTANT**: DO NOT USE `/tmp`. This is a working directory to store all important intermediate files for Caper. This directory is also used to store big cached files for localization of remote files. e.g. to run pipelines locally with remote files (`gs://`, `s3://`, `http://`, ...) copies of such files are stored here.
-	slurm-partition | SLURM partition. Define only if required by a cluster. You must define it for Stanford Sherlock.
-	slurm-account | SLURM partition. Define only if required by a cluster. You must define it for Stanford SCG.
-	sge-pe | Parallel environment of SGE. Find one with `$ qconf -spl` or ask you admin to add one if not exists.
-	aws-batch-arn | ARN for AWS Batch.
-	aws-region | AWS region (e.g. us-west-1)
-	aws-out-dir | Output bucket path for AWS. This should start with `s3://`.
-	gcp-prj | Google Cloud Platform Project
-	gcp-out-dir | Output bucket path for Google Cloud Platform. This should start with `gs://`.
-
-7) To use Caper on Google Cloud Platform (GCP), we provide a shell script to create a Caper server instance on Google Cloud.
-See [this](scripts/gcp_caper_server/README.md) for details.
-
-8) To use Caper on Amazon Web Service (AWS), we provide a shell script to create a Caper server instance on AWS.
-See [this](scripts/aws_caper_server/README.md) for details.
+6) Edit `~/.caper/default.conf`. **DO NOT LEAVE ANY PARAMETERS UNDEFINED OR CAPER WILL NOT WORK CORRECTLY**
 
 
 ## Output directory
@@ -90,491 +72,87 @@ Therefore, change directory first and run Caper there.
 $ cd [OUTPUT_DIR]
 ```
 
-## Activating Conda environment
+## Docker, Singularity and Conda
 
-If you want to use your Conda environment for Caper, then activate your Conda environment right before running/submitting `caper run` or `caper server`.
+For local backends (`local`, `slurm`, `sge`, `pbs` and `lsf`), you can use `--docker`, `--singularity` or `--conda` to run pipelines within one of these environment. For example, `caper run ... --singularity docker://ubuntu:latest` will run each task within a Singularity image built from a docker image `ubuntu:latest`. These parameters can also be used as flags. If used as a flag, Caper will try to find a default docker/singularity/conda in WDL. e.g. All ENCODE pipelines have default docker images defined within WDL's meta section (under key `caper_docker` or `default_docker`).
+
+For Conda users, make sure that you have installed pipeline's Conda environments before running pipelines. Caper only knows Conda environment's name to run a task on.
+
+For Singularity users, if you provide a Singularity image based on docker `docker://` then Caper will locally build a temporary Singularity image (`*.sif`) under `SINGULARITY_CACHEDIR` (defaulting to `~/.singularity/cache` if not defined). It's synchronized for all tasks, which means that one task will build the image and others will wait and use the built image later. Building can take some time according to the size of the original docker image.
+
+
+Take a look at the following examples:
 ```bash
-$ conda activate [PIPELINE_CONDA_ENV]
-$ caper run ...
-$ sbatch ... --wrap "caper run ..."
+$ caper run test.wdl --docker # can be used as a flag too, Caper will find docker image from WDL if defined
+$ caper run test.wdl --singularity docker://ubuntu:latest
+$ caper submit test.wdl --conda your_conda_env_name
 ```
+An environemnt defined here will be overriden by those defined in WDL task's `runtime`. Therefore, think of this as a base/default environment for your pipeline. You can define per-task environment in each WDL task's `runtime`.
 
-## Running pipelines on Stanford Sherlock
+For cloud backends (`gcp` and `aws`), you always need to use `--docker` (can be skipped). Caper will automatically try to find a base docker image defined in your WDL. For other pipelines, define a base docker image in Caper's CLI or directly in each WDL task's `runtime`.
 
-> **IMPORTANT**: DO NOT INSTALL CAPER, CONDA AND PIPELINE'S WDL ON `$SCRATCH` OR `$OAK` STORAGES. You will see `Segmentation Fault` errors. Install these executables (Caper, Conda, WDL, ...) on `$HOME` OR `$PI_HOME`. You can still use `$OAK` for input data (e.g. FASTQs defined in your input JSON file) but not for outputs, which means that you should not run Caper on `$OAK`. `$SCRATCH` and `$PI_SCRATCH` are okay for both input and output data so run Caper on them. Running Croo to organize outputs into `$OAK` is okay.
 
-Submit a Caper leader job (`caper run`) to SLURM. For a partition `-p [SLURM_PARTITON]`, make sure that you use the same SLURM partition (`slurm-partition` in `~/.caper/default.conf`) as defined in Caper's configuration file. `-J [JOB_NAME]` is to identify Caper's leader job for each workflow. Make a separate directory for each workflow output will be written to each directory.
+## Important notes for Conda users
 
+Since Caper>=2.0 you don't have to activate Conda environment before running pipelines. Caper will internally run `conda run -n ENV_NAME /bin/bash script.sh`. Just make sure that you correctly installed given pipeline's Conda environment(s).
+
+
+## Important notes for Stanford HPC (Sherlock and SCG) users
+
+DO NOT INSTALL CAPER, CONDA AND PIPELINE'S WDL ON `$SCRATCH` OR `$OAK` STORAGES. You will see `Segmentation Fault` errors. Install these executables (Caper, Conda, WDL, ...) on `$HOME` OR `$PI_HOME`. You can still use `$OAK` for input data (e.g. FASTQs defined in your input JSON file) but not for outputs, which means that you should not run Caper on `$OAK`. `$SCRATCH` and `$PI_SCRATCH` are okay for both input and output data so run Caper on them. Running Croo to organize outputs into `$OAK` is okay.
+
+
+## Running pipelines on HPCs
+
+In order to run a pipeline inside Singularity image or Conda environment use `--singularity` or `--conda` since most HPCs do not allow docker. For example, submit `caper run ... --singularity` as a leader job (with long walltime and enough resources like 1-2 cpus and 4GB of RAM). Then Caper's leader job itself will submit its child jobs to the job engine so that both leader and child jobs can be found with `squeue` or `qstat`.
+
+Here are some example command lines to submit Caper as a leader job. Make sure that you correctly configured Caper with `caper init` and filled all parameters in the conf file `~/.caper/default.conf`.
 ```bash
-$ # DO NOT RUN THIS ON OAK STORAGE!
-$ # conda activate here if required
-$ cd [OUTPUT_DIR]  # make a separate directory for each workflow.
-$ sbatch -p [SLURM_PARTITON] -J [JOB_NAME] --export=ALL --mem 3G -t 4-0 --wrap "caper run [WDL] -i [INPUT_JSON]"
-```
+# make a separate directory for each workflow.
+$ cd [OUTPUT_DIR]
 
-A Caper leader job will `sbatch` lots of sub-tasks to SLURM so `squeue` will be mixed up with a leader job and its children jobs. It will be more convenient to filter out children jobs.
-```
+# Example for Stanford Sherlock
+$ sbatch -p [SLURM_PARTITON] -J [WORKFLOW_NAME] --export=ALL --mem 4G -t 4-0 --wrap "caper run [WDL] -i [INPUT_JSON] --singularity --db file --file-db [METADATA_DB_PATH_FOR_CALL_CACHING]"
+
+# Example for Stanford SCG
+$ sbatch -A [SLURM_ACCOUNT] -J [WORKFLOW_NAME] --export=ALL --mem 3G -t 4-0 --wrap "caper run [WDL] -i [INPUT_JSON] --singularity --db file --file-db [METADATA_DB_PATH_FOR_CALL_CACHING]"
+
+# Example for General SLURM cluster
+$ sbatch -A [SLURM_ACCOUNT] -p [SLURM_PARTITON] -J [WORKFLOW_NAME] --export=ALL --mem 3G -t 4-0 --wrap "caper run [WDL] -i [INPUT_JSON] --singularity --db file --file-db [METADATA_DB_PATH_FOR_CALL_CACHING]"
+
+# Example for SGE
+$ echo "caper run [WDL] -i [INPUT_JSON] --singularity --db file --file-db [METADATA_DB_PATH_FOR_CALL_CACHING]" | qsub -V -N [JOB_NAME] -l h_rt=144:00:00 -l h_vmem=3G
+
+# Check status of leader/child jobs
 $ squeue -u $USER | grep -v cromwell
-```
-
-## Running pipelines on Stanford SCG
-
-Submit a Caper leader job for `caper run` to SLURM. For a SLURM account `-A [SLURM_ACCOUNT]` (this can be different from your own account, talk to your PI or admin), make sure that you use the same SLURM account (`slurm-account` in `~/.caper/default.conf`) as defined in Caper's configuration file. `-J [JOB_NAME]` is to identify Caper's leader job for each workflow. Make a separate directory for each workflow output will be written to each directory.
-
-```bash
-$ # conda activate here if required
-$ cd [OUTPUT_DIR]  # make a separate directory for each workflow
-$ sbatch -A [SLURM_ACCOUNT] -J [JOB_NAME] --export=ALL --mem 3G -t 4-0 --wrap "caper run [WDL] -i [INPUT_JSON]"
-```
-
-A Caper leader job will `sbatch` lots of sub-tasks to SLURM so `squeue` will be mixed up with a leader job and its children jobs. It will be more convenient to filter out children jobs.
-```
-$ squeue -u $USER | grep -v cromwell
-```
-
-## Running pipelines on SLURM clusters
-
-Submit a Caper leader job for `caper run` to SLURM. Define or skip a SLURM account `-A [SLURM_ACCOUNT]` or a SLURM partition `-p [SLURM_PARTITON]` according to your SLURM's configuration. Make sure that those parameters match with whatever defined (`slurm-account` or `slurm-partition` in `~/.caper/default.conf`) in Caper's configuration file. `-J [JOB_NAME]` is to identify Caper's leader job for each workflow. Make a separate directory for each workflow output will be written to each directory.
-
-```bash
-$ # conda activate here if required
-$ cd [OUTPUT_DIR]  # make a separate directory for each workflow
-$ sbatch -A [SLURM_ACCOUNT] -p [SLURM_PARTITON] -J [JOB_NAME] --export=ALL --mem 3G -t 4-0 --wrap "caper run [WDL] -i [INPUT_JSON]"
-```
-
-A Caper leader job will `sbatch` lots of sub-tasks to SLURM so `squeue` will be mixed up with a leader job and its children jobs. It will be more convenient to filter out children jobs.
-```
-$ squeue -u $USER | grep -v cromwell
-```
-
-## Running pipelines on SGE clusters
-
-Submit a Caper leader job for `caper run` to SGE. `-N [JOB_NAME]` is to identify Caper's leader job for each workflow. Make a separate directory for each workflow output will be written to each directory.
-```bash
-$ # conda activate here if required
-$ cd [OUTPUT_DIR]  # make a separate directory for each workflow
-$ echo "caper run [WDL] -i [INPUT_JSON]" | qsub -V -N [JOB_NAME] -l h_rt=144:00:00 -l h_vmem=3G
-```
-
-A Caper leader job will `qsub` lots of sub-tasks to SGE so `qstat` will be mixed up with a leader job and its children jobs. It will be more convenient to filter out children jobs.
-```
-$ qstat | grep -v cromwell
 ```
 
 ## Running pipelines on cloud platforms (GCP and AWS)
 
-Create a small leader instance on your GCP project/AWS region. Follow above installation instruction to install `Java`, Caper and Docker.
+Follow these instructions for [GCP](scripts/gcp_caper_server/README.md) and [AWS](scripts/aws_caper_server/README.md).
 
-> **IMPORTANT**: It's **STRONGLY** recommended to attach/mount a persistent disk/EBS volume with enough space to it. Caper's call-caching file DB grows quickly to reach 10 GB, which is a default size for most small instances.
 
-Also, make sure that `local-loc-dir` in `~/.caper/default.conf` points to a directory on a large disk. All intermediate files and big cached files for inter-storage transfer will be stored there.
+## Running pipelines on a local machine
 
-Mount a persistent disk and change directory into it. A **BIG** DB file to enable Cromwell's call-caching (re-using previous failed workflow's outputs) will be generated on this current working directory.
+Make a separate directory for each workflow. Caper maximizes parallelization (depending on the task tree of a given WDL). So make sure that your local machine has enough resources to run it. You can control number of concurrent tasks in a pipeline. For example, serialize all tasks with `--max-concurrent-tasks 1`.
+
 ```bash
-$ cd /mnt/[MOUNTED_DISK]/[OUTPUT_DIR]
-```
-
-Make a screen to keep the session alive. Use the same command line to reattach to it.
-```bash
-$ screen -RD caper_server
-```
-
-Run a server on a screen. Detach from the screen (`Ctrl+A` and then `d`).
-```bash
-$ caper server
-```
-
-Submit a workflow to the server. All pipeline outputs will be written to `gcp-out-dir` (for GCP) or `aws-out-dir` (for AWS) in defined `~/.caper/default.conf`.
-```bash
-$ caper submit [WDL] -i [INPUT_JSON]
-```
-
-Monitor your workflows.
-```
-$ caper list
-```
-
-## Running pipelines on general computers
-
-Make a separate directory for each workflow.
-```bash
-$ # conda activate here if required
 $ cd [OUTPUT_DIR]  # make a separate directory for each workflow
-$ caper run [WDL] -i [INPUT_JSON]
-```
-
-## Running pipelines on a custom backend
-
-If Caper's built-in backends don't work as expected on your clusters (e.g. due to different resource settings), then you can override built-in backends with your own configuration file (e.g. `your.backend.conf`). Caper generates a `backend.conf` for built-in backends on a temporary directory.
-
-Find this `backend.conf` first by dry-running `caper run [WDL] --dry-run ...`. For example of a `slurm` backend:
-```
-$ caper run main.wdl --dry-run
-2020-07-07 11:18:13,196|caper.caper_runner|INFO| Adding encode-dcc-1016 to env var GOOGLE_CLOUD_PROJECT
-2020-07-07 11:18:13,197|caper.caper_base|INFO| Creating a timestamped temporary directory. /mnt/data/scratch/leepc12/test_caper_tmp/main/20200707_111813_197082
-2020-07-07 11:18:13,197|caper.caper_runner|INFO| Localizing files on work_dir. /mnt/data/scratch/leepc12/test_caper_tmp/main/20200707_111813_197082
-2020-07-07 11:18:13,829|caper.cromwell|INFO| Validating WDL/inputs/imports with Womtool...
-2020-07-07 11:18:16,034|caper.cromwell|INFO| Womtool validation passed.
-2020-07-07 11:18:16,035|caper.caper_runner|INFO| launching run: wdl=/mnt/data2/scratch/leepc12/test_wdl1_sub/main.wdl, inputs=None, backend_conf=/mnt/data/scratch/leepc12/test_caper_tmp/main/20200707_111813_197082/backend.conf
-```
-
-Look for a file defined with a Java parameter `-Dconfig.file` and find a backend of interest (`slurm` in this example) in the file.
-```
-include required(classpath("application"))
-backend {
-  default = "slurm"
-  providers {
-
-  ...
-
-    slurm {
-      config {
-        default-runtime-attributes {
-          time = 24
-        }
-        concurrent-job-limit = 1000
-        script-epilogue = "sleep 10 && sync"
-        filesystems {
-          local {
-            localization = [
-              "soft-link"
-              "hard-link"
-              "copy"
-            ]
-            caching {
-              check-sibling-md5 = true
-              duplication-strategy = [
-                "soft-link"
-                "hard-link"
-                "copy"
-              ]
-              hashing-strategy = "path+modtime"
-            }
-          }
-        }
-        run-in-background = true
-        runtime-attributes = """String? docker
-String? docker_user
-Int cpu = 1
-Int? gpu
-Int? time
-Int? memory_mb
-String? slurm_partition
-String? slurm_account
-String? slurm_extra_param
-String? singularity
-String? singularity_bindpath
-String? singularity_cachedir
-"""
-        submit = """if [ -z \"$SINGULARITY_BINDPATH\" ]; then export SINGULARITY_BINDPATH=${singularity_bindpath}; fi; \
-if [ -z \"$SINGULARITY_CACHEDIR\" ]; then export SINGULARITY_CACHEDIR=${singularity_cachedir}; fi;
-
-ITER=0
-until [ $ITER -ge 3 ]; do
-    sbatch \
-        --export=ALL \
-        -J ${job_name} \
-        -D ${cwd} \
-        -o ${out} \
-        -e ${err} \
-        ${'-t ' + time*60} \
-        -n 1 \
-        --ntasks-per-node=1 \
-        ${'--cpus-per-task=' + cpu} \
-        ${true="--mem=" false="" defined(memory_mb)}${memory_mb} \
-        ${'-p ' + slurm_partition} \
-        ${'--account ' + slurm_account} \
-        ${'--gres gpu:' + gpu} \
-        ${slurm_extra_param} \
-        --wrap "${if !defined(singularity) then '/bin/bash ' + script
-                  else
-                    'singularity exec --cleanenv ' +
-                    '--home ' + cwd + ' ' +
-                    (if defined(gpu) then '--nv ' else '') +
-                    singularity + ' /bin/bash ' + script}" \
-        && break
-    ITER=$[$ITER+1]
-    sleep 30
-done
-"""
-        root = "/mnt/data/scratch/leepc12/caper_out"
-        exit-code-timeout-seconds = 360
-        check-alive = """for ITER in 1 2 3; do
-    CHK_ALIVE=$(squeue --noheader -j ${job_id} --format=%i | grep ${job_id})
-    if [ -z "$CHK_ALIVE" ]; then if [ "$ITER" == 3 ]; then /bin/bash -c 'exit 1'; else sleep 30; fi; else echo $CHK_ALIVE; break; fi
-done
-"""
-        kill = "scancel ${job_id}"
-        job-id-regex = "Submitted batch job (\\d+).*"
-      }
-      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
-    }
-  ...
-
-}
-
-...
-
-````
-
-Some part of the script (wrapped in `${}`) is written in WDL. For example, `${true="--mem=" false="" defined(memory_mb)}`, if `memory_mb` is defined it will print `--mem`). For such WDL expressions, you can use any variables defined in `runtime-attributes`.
-
-For example, if your cluster does not allow importing all environment variables (`sbatch --export=ALL` ...)  then you can remove `--export=ALL` from the above script.
-
-There is a retrial logic implemented in this SLURM backend. It retries submitting up to 3 times for some SLURM clusters.
-```
-ITER=0; until [ $ITER -ge 3 ]; do
-...
-ITER=$[$ITER+1]; sleep 30; done
-```
-
-Also, there is another logic to use Singularity. If `singularity` is not given, then Cromwell will run `/bin/bash ${script}` otherwise this backend will collect some Singularity specific environment variables and finally run `singularity exec --cleanenv --home ${cwd} ${singularity} /bin/bash ${script}`. `${singularity}` is a variable that has singularity image location defined in `runtime-attributes` mentioned above.
-```
-sbatch ... --wrap "${if defined(singularity) then '' else '/bin/bash ${script} #`} ..."
-```
-
-There are some built-in variables (`out`, `err`, `cwd`, `script`, `cpu`, `memory_mb` and `time`) in Cromwell, which are important to keep Cromwell's task running. For example, if you remove `-o ${out}` from the script and Cromwell will fail to find `stdout` on output directory, which will lead to a pipeline failure.
-
-See more [details](https://cromwell.readthedocs.io/en/stable/Configuring/) about a backend configuration file.
-
-Your custom `your.backend.conf` file will override on Caper's existing built-in backend, so keep modified parts (`submit` command line in this example) only in your `your.backend.conf` file.
-```
-backend {
-  default = "slurm"
-  providers {
-    slurm {
-        submit = """sbatch         --export=ALL         -J ${job_name}         -D ${cwd}         -o ${out}         -e ${err}         ${"-t " + time*60}         -n 1         --ntasks-per-node=1         ${true="--cpus-per-task=" false="" defined(cpu)}${cpu}         ${true="--mem=" false="" defined(memory_mb)}${memory_mb}         ${"-p " + slurm_partition}         ${"--account " + slurm_account}         ${true="--gres gpu:" false="" defined(gpu)}${gpu}         ${slurm_extra_param}         --wrap "${if defined(singularity) then '' else             '/bin/bash ${script} #'}             if [ -z \"$SINGULARITY_BINDPATH\" ]; then             export SINGULARITY_BINDPATH=${singularity_bindpath}; fi;             if [ -z \"$SINGULARITY_CACHEDIR\" ]; then             export SINGULARITY_CACHEDIR=${singularity_cachedir}; fi;             singularity exec --cleanenv --home ${cwd}             ${if defined(gpu) then '--nv' else ''}             ${singularity} /bin/bash ${script}" && break
-    ITER=$[$ITER+1]; sleep 30; done
-    """
-    }
-  }
-}
-```
-
-And then run `caper run` with your `your.backend.conf`.
-```
-$ caper run ... --backend-file your.backend.conf
+$ caper run [WDL] -i [INPUT_JSON] --docker
 ```
 
 
-## Caper server heartbeat (running multiple servers)
+## How to configure resource parameters for HPCs
 
-Caper server writes a heartbeat file (specified by `--server-heartbeat-file`) on every 120 seconds (controlled by `--server-heartbeat-timeout`). This file will contain an IP(hostname)/PORT pair of the running `caper server`.
-
-Example heartbeat file:
-```bash
-$ cat ~/.caper/default_server_heartbeat
-your.hostname.com:8000
+Each HPC backend (`slurm`, `sge`, `pbs` and `lsf`) has its own resource parameter. Find it in Caper's configuration file (`~/.caper/default.conf`) and edit it. For example, the default resource parameter for SLURM looks like the following:
 ```
-
-This heartbeat file is useful when users don't want to find IP(hostname)/PORT of a running `caper server` especially when they `qsub`bed or `sbatch`ed `caper server` on their clusters. For such cases, IP (hostname of node/instance) of the server is later determined after the cluster engine starts the submitted `caper server` job and it's inconvenient for the users to find the IP (hostname) of the running server manually with `qstat` or `squeue` and add it back to Caper's configuration file `~/.caper/default.conf`.
-
-Therefore, Caper defaults to use this heartbeat file (can be disabled by a flag `--no-server-heartbeat`). So if client-side caper functions like `caper list` and `caper metadata` finds this heartbeat file and automatically parse it to get an IP/PORT pair.
-
-However, there can be a conflict if users want to run multiple `caper server`s on the same machine (or multiple machines sharing the same caper configuration directory `~/.caper/` and hence the same default heartbeat file). For such cases, users can disable this heartbeat feature by adding the following line to their configuration file: e.g. `~/.caper/default.conf`.
-```bash
-no-server-heartbeat=True
+slurm-resource-parameter=-n 1 --ntasks-per-node=1 --cpus-per-task=${cpu} ${if defined(memory_mb) then "--mem=" else ""}${memory_mb}${if defined(memory_mb) then "M" else ""} ${if defined(time) then "--time=" else ""}${time*60} ${if defined(gpu) then "--gres=gpu:" else ""}${gpu}
 ```
+This should be a one-liner and WDL syntax and Cromwell's built-in resource variables like `cpu`(number of cores for a task), `memory_mb`(total amount of memory for a task in MB), `time`(walltime for a task in hour) and `gpu`(name of gpu unit or number of gpus) are allowed in `${}` notation. See https://github.com/openwdl/wdl/blob/main/versions/1.0/SPEC.md for WDL syntax.
 
-Then start multiple servers with different port and DB (for example of MySQL). Users should make sure that each server uses a different DB (file or MySQL server port, whatever...) since there is no point of using multiple Caper servers with the same DB. For example of MySQL, users should not forget to spin up multiple MySQL servers with different ports.
-
-```bash
-$ caper server --port 8000 --mysql-db-port 3306 ... &
-$ caper server --port 8001 --mysql-db-port 3307 ... &
-$ caper server --port 8002 --mysql-db-port 3308 ... &
-```
-
-Send queries to a specific server.
-```bash
-$ caper list --port 8000
-$ caper list --port 8001
-$ caper list --port 8002
-```
-
-## Metadata database
-
-If you are not interested in resuming failed workflows skip this section.
-
-Cromwell metadata DB is used for call-caching (re-using outputs from previous workflows). Caper>=0.6 defaults to use `in-memory` DB, whose metadata will be all lost when the Caper process stops.
-
-In order to use call-caching, choose one of the following metadata database types with `--db` or `db=` in your Caper conf file `~/.caper/default.conf`.
-
-1) `mysql` (**RECOMMENDED**): We provide [shell scripts](#mysql-server) to run a MySQL server without root. You need either Docker or Singularity installed on your system.
-
-2) `postgresql` (experimental): We don't provide a method to run PostgreSQL server and initialize it correctly for Crowmell. See [this](https://cromwell.readthedocs.io/en/stable/Configuring/) for details.
-
-3) `file` (**UNSTABLE**, not recommended): This is Cromwell's built-in [HyperSQL DB file mode](#file-database). Caper<0.6 defaulted to use it but a file DB turns out to be very unstable and get corrupted easily.
-
-## MySQL database
-
-We provide [shell scripts](bin/run_mysql_server_docker.sh) to run a MySQL server in a container with docker/singularity. Once you have a running MySQL server, add the followings to Caper's conf file `~/.caper/default.conf`. You may need to change the port number if it conflicts.
-
-```
-db=mysql
-mysql-db-port=3306
-```
-
-1) docker
-
-	Ask your admin to add you to the `docker` group or if you are root then install Docker, create a group `docker` and add yourself to the group `docker`.
-
-	```bash
-	$ sudo apt-get install docker.io
-	$ sudo groupadd docker
-	$ sudo usermod -aG docker $USER
-	```
-
-	**RE-LOGIN** and check if Docker `hello-world` works.
-
-	```bash
-	$ docker run hello-world
-	```
-
-	Run the following command line. `PORT` and `CONTAINER_NAME` are optional. MySQL server will run in background.
-
-	```bash
-	$ run_mysql_server_docker.sh [DB_DIR] [PORT]
-	```
-
-	If you see any conflict in `PORT` or `CONTAINER_NAME`, then try with higher `PORT` or different `CONTAINER_NAME` (`mysql_cromwell` by default).
-
-	Example conflict in `PORT`. Try with `3307` or higher.
-	```
-	[PORT] (3306) already taken.
-	```
-
-	Example conflict in `CONTAINER_NAME`. Try with `mysql_cromwell2`.
-	```bash
-	docker: Error response from daemon: Conflict. The container name "/mysql_cromwell" is already in use by container 0584ec7affed0555a4ecbd2ed86a345c542b3c60993960408e72e6ea803cb97e. You have to remove (or rename) that container to be able to reuse that name..
-	```
-
-	Check if MySQL server is running.
-	```bash
-	$ docker ps  # find your MySQL docker container
-	```
-
-	To stop/kill a running MySQL server,
-	```bash
-	$ docker stop [CONTAINER_NAME]  # you can also use a container ID found in the above cmd
-	```
-
-	If you see the following authentication error:
-	```bash
-	Caused by: java.sql.SQLException: Access denied for user 'cromwell'@'localhost' (using password: YES)
-	```
-
-	Then try to remove a volume for MySQL's docker container. See [this](https://github.com/docker-library/mariadb/issues/62#issuecomment-366933805) for details.
-	```bash
-	$ docker volume ls  # find [VOLUME_ID] for your container
-	$ docker volume rm [VOLUME_ID]
-	```
-
-2) Singularity
-
-	Run the following command line. `PORT` and `CONTAINER_NAME` are optional. MySQL server will run in background as a Singularity instance.
-
-	```bash
-	$ run_mysql_server_singularity.sh [DB_DIR] [PORT] [CONTAINER_NAME]
-	```
-
-	If you see any conflict in `PORT` or `CONTAINER_NAME`, then try with higher `PORT` or different `CONTAINER_NAME` (`mysql_cromwell` by default).
-
-	Example conflict in `PORT`. Try with `3307` or higher.
-	```
-	[PORT] (3306) already taken.
-	```
-
-	Example conflict in `CONTAINER_NAME`. Try with `mysql_cromwell2`.
-	```
-	ERROR: A daemon process is already running with this name: mysql_cromwell
-	ABORT: Aborting with RETVAL=255
-	```
-
-	To stop/kill a running MySQL server.
-	```bash
-	$ singularity instance list  # find your MySQL singularity container
-	$ singularity instance stop [CONTAINER_NAME]
-	```
-
-## PostgreSQL database
-
-Add the followings to Caper's conf file `~/.caper/default.conf`. You may need to change the port number if it conflicts.
-```
-db=postgresql
-postgresql-db-port=5432
-```
-
-You do not need superuser privilege to make your own database once you have PostgreSQL installed on your system. Ask your admin to install it.
-
-Make sure to match `DB_PORT`, `DB_NAME`, `DB_USER` and `DB_PASSWORD` with Caper's parameters `--postgresql-db-port`, `--postgresql-db-name`, `--postgresql-db-user`, and `--postgresql-db-password`. You can also define them in  `~/.caper/default.conf`.
-
-```bash
-# make sure to match those variables with corresponding Caper's parameters.
-$ DB_PORT=5432
-$ DB_NAME=cromwell
-$ DB_USER=cromwell
-$ DB_PASSWORD=cromwell
-
-# initialize PostgreSQL server with a specific data path
-# actual data will be stored on directory $DB_FILE_PATH
-$ DB_FILE_PATH=my_postgres
-$ initdb -D $DB_FILE_PATH -U $USER
-
-# start PostgreSQL server with a specific port
-$ DB_LOG_FILE=pg.log
-$ pg_ctl -D $DB_FILE_PATH -o "-F -p $DB_PORT" -l $DB_LOG_FILE start
-
-# create DB for Cromwell
-$ createdb $DB_NAME
-
-# add extension for Cromwell
-$ psql -d $DB_NAME -c "create extension lo;"
-
-# make a role (user)
-$ psql -d $DB_NAME -c "create role $DB_USER with superuser login password $DB_PASSWORD"
-```
-
-
-## File database
-
-> **WARINING**: Using this type of metadata database is **NOT RECOMMENDED**. It's unstable and fragile.
-
-Define file DB parameters in `~/.caper/default.conf`.
-
-```
-db=file
-file-db=/YOUR/FILE/DB/PATH/PREFIX
-```
-
-This file DB is genereted on your working directory by default. Its default filename prefix is `caper_file_db.[INPUT_JSON_BASENAME_WO_EXT]`. A DB is consist of multiple files and directories with the same filename prefix.
-
-Unless you explicitly define `file-db` in your configuration file `~/.caper/default.conf` this file DB name will depend on your input JSON filename. Therefore, you can simply resume a failed workflow with the same command line used for starting a new pipeline.
+Note that Cromwell's implicit type conversion (`WomLong` to `String`) seems to be buggy for `WomLong` type memory variables such as `memory_mb` and `memory_gb`. So be careful about using the `+` operator between `WomLong` and other types (`String`, even `Int`). For example, `${"--mem=" + memory_mb}` will not work since `memory_mb` is `WomLong` type. Use `${"if defined(memory_mb) then "--mem=" else ""}{memory_mb}${"if defined(memory_mb) then "mb " else " "}`. See https://github.com/broadinstitute/cromwell/issues/4659 for details.
 
 
 # DETAILS
 
 See [details](DETAILS.md).
-
-
-## Profiling/monitoring resources on Google Cloud
-
-A workflow ran with Caper>=1.2.0 on `gcp` backend has a monitoring log (`monitoring.log`) by default on each task's execution directory. This log file includes useful resources data on an instance like used memory, used disk space and total cpu percentage.
-
-`caper gcp_monitor` recursively parses such monitoring log files and show statistics of them in a tab-separated table. `caper gcp_monitor` can take `metadata.json` file URI or a workflow ID if there is a running `caper server`. `--json-format` is optional to print out detailed outputs in a JSON format.
-
-```bash
-$ caper gcp_monitor METADATA_JSON_FILE_OR_WORKFLOW_ID ... --json-format
-```
-
-For further analysis on resource data, use `caper gcp_res_analysis`. `--plot-pdf` is optional to make a multipage PDF file with scatter plots.
-```bash
-$ caper gcp_res_analysis METADATA_JSON_FILE_OR_WORKFLOW_ID ... --plot-pdf [PLOT_PDF_PATH]
-```
-
-Define task's input file variables to limit analysis on specific tasks and input variables. Use `--in-file-vars-def-json` to define it.
- Example JSON files can be found at the following URLs:
-- ENCODE ATAC-seq pipeline: [Result JSON](https://storage.googleapis.com/caper-data/gcp_resource_analysis/in_file_vars_json/atac.json)
-- ENCODE ChIP-seq pipeline: [Result JSON](https://storage.googleapis.com/caper-data/gcp_resource_analysis/in_file_vars_json/chip.json)
-
-Example plots:
-- ENCODE ATAC-seq pipeline: [Plot PDF](https://storage.googleapis.com/caper-data/gcp_resource_analysis/example_plot/atac.pdf)

--- a/caper/caper_client.py
+++ b/caper/caper_client.py
@@ -164,6 +164,8 @@ class CaperClientSubmit(CaperClient):
         sge_extra_param=None,
         pbs_queue=None,
         pbs_extra_param=None,
+        lsf_queue=None,
+        lsf_extra_param=None,
     ):
         """Submit subcommand needs much more parameters than other client subcommands.
 
@@ -192,6 +194,10 @@ class CaperClientSubmit(CaperClient):
                 PBS queue.
             pbs_extra_param:
                 PBS extra parameter to be appended to qsub command line.
+            lsf_queue:
+                LSF queue.
+            lsf_extra_param:
+                LSF extra parameter to be appended to bsub command line.
         """
         super().__init__(
             local_loc_dir=local_loc_dir,
@@ -216,6 +222,8 @@ class CaperClientSubmit(CaperClient):
             sge_extra_param=sge_extra_param,
             pbs_queue=pbs_queue,
             pbs_extra_param=pbs_extra_param,
+            lsf_queue=lsf_queue,
+            lsf_extra_param=lsf_extra_param,
         )
 
         self._caper_labels = CaperLabels()

--- a/caper/caper_client.py
+++ b/caper/caper_client.py
@@ -8,7 +8,6 @@ from .caper_wdl_parser import CaperWDLParser
 from .caper_workflow_opts import CaperWorkflowOpts
 from .cromwell import Cromwell
 from .cromwell_rest_api import CromwellRestAPI, has_wildcard, is_valid_uuid
-from .singularity import Singularity
 
 logger = logging.getLogger(__name__)
 
@@ -233,8 +232,7 @@ class CaperClientSubmit(CaperClient):
         user=None,
         docker=None,
         singularity=None,
-        singularity_cachedir=Singularity.DEFAULT_SINGULARITY_CACHEDIR,
-        no_build_singularity=False,
+        conda=None,
         max_retries=CaperWorkflowOpts.DEFAULT_MAX_RETRIES,
         memory_retry_multiplier=CaperWorkflowOpts.DEFAULT_MEMORY_RETRY_MULTIPLIER,
         gcp_monitoring_script=CaperWorkflowOpts.DEFAULT_GCP_MONITORING_SCRIPT,
@@ -277,18 +275,9 @@ class CaperClientSubmit(CaperClient):
                 This will be overriden by existing "docker" attr defined in
                 WDL's task's "runtime {} section.
             singularity:
-                Singularity image to run a workflow on.
-                To use this, do not define "docker" attribute in
-                WDL's task's "runtime {} section.
-            singularity_cachedir:
-                Cache directory for local Singularity images.
-                If there is a shell environment variable SINGULARITY_CACHEDIR
-                define then this parameter will be ignored.
-            no_build_singularity:
-                Do not build local singularity image.
-                However, a local singularity image will be eventually built on
-                env var SINGULARITY_CACHEDIR.
-                Therefore, use this flag if you have already built it.
+                Default Singularity image to run a workflow on.
+            conda:
+                Default Conda environment to run a workflow.
             max_retries:
                 Max retrial for a failed task. 0 or None means no trial.
             memory_retry_multiplier:
@@ -353,8 +342,7 @@ class CaperClientSubmit(CaperClient):
             custom_options=options,
             docker=docker,
             singularity=singularity,
-            singularity_cachedir=singularity_cachedir,
-            no_build_singularity=no_build_singularity,
+            conda=conda,
             max_retries=max_retries,
             memory_retry_multiplier=memory_retry_multiplier,
             gcp_monitoring_script=gcp_monitoring_script,

--- a/caper/caper_wdl_parser.py
+++ b/caper/caper_wdl_parser.py
@@ -11,9 +11,9 @@ class CaperWDLParser(WDLParser):
 
     RE_WDL_COMMENT_DOCKER = r'^\s*\#\s*CAPER\s+docker\s(.+)'
     RE_WDL_COMMENT_SINGULARITY = r'^\s*\#\s*CAPER\s+singularity\s(.+)'
-    WDL_WORKFLOW_META_DOCKER = ('default_docker', 'caper_docker')
-    WDL_WORKFLOW_META_SINGULARITY = ('default_singularity', 'caper_singularity')
-    WDL_WORKFLOW_META_CONDA = (
+    WDL_WORKFLOW_META_DOCKER_KEYS = ('default_docker', 'caper_docker')
+    WDL_WORKFLOW_META_SINGULARITY_KEYS = ('default_singularity', 'caper_singularity')
+    WDL_WORKFLOW_META_CONDA_KEYS = (
         'default_conda',
         'default_conda_env',
         'caper_conda',
@@ -25,6 +25,12 @@ class CaperWDLParser(WDLParser):
 
     @property
     def caper_docker(self):
+        """Backward compatibility for property name. See property default_docker.
+        """
+        return self.default_docker
+
+    @property
+    def default_docker(self):
         """Find a default Docker image in WDL for Caper.
 
         Backward compatibililty:
@@ -32,7 +38,7 @@ class CaperWDLParser(WDLParser):
             if WDL_WORKFLOW_META_DOCKER doesn't exist in workflow's meta
         """
         if self.workflow_meta:
-            for docker_key in CaperWDLParser.WDL_WORKFLOW_META_DOCKER:
+            for docker_key in CaperWDLParser.WDL_WORKFLOW_META_DOCKER_KEYS:
                 if docker_key in self.workflow_meta:
                     return self.workflow_meta[docker_key]
 
@@ -42,6 +48,12 @@ class CaperWDLParser(WDLParser):
 
     @property
     def caper_singularity(self):
+        """Backward compatibility for property name. See property default_singularity.
+        """
+        return self.default_singularity
+
+    @property
+    def default_singularity(self):
         """Find a default Singularity image in WDL for Caper.
 
         Backward compatibililty:
@@ -49,7 +61,7 @@ class CaperWDLParser(WDLParser):
             if WDL_WORKFLOW_META_SINGULARITY doesn't exist in workflow's meta
         """
         if self.workflow_meta:
-            for singularity_key in CaperWDLParser.WDL_WORKFLOW_META_SINGULARITY:
+            for singularity_key in CaperWDLParser.WDL_WORKFLOW_META_SINGULARITY_KEYS:
                 if singularity_key in self.workflow_meta:
                     return self.workflow_meta[singularity_key]
 
@@ -58,10 +70,10 @@ class CaperWDLParser(WDLParser):
             return ret[0].strip('"\'')
 
     @property
-    def caper_conda(self):
+    def default_conda(self):
         """Find a default Conda environment name in WDL for Caper.
         """
         if self.workflow_meta:
-            for conda_key in CaperWDLParser.WDL_WORKFLOW_META_CONDA:
+            for conda_key in CaperWDLParser.WDL_WORKFLOW_META_CONDA_KEYS:
                 if conda_key in self.workflow_meta:
                     return self.workflow_meta[conda_key]

--- a/caper/caper_wdl_parser.py
+++ b/caper/caper_wdl_parser.py
@@ -11,23 +11,30 @@ class CaperWDLParser(WDLParser):
 
     RE_WDL_COMMENT_DOCKER = r'^\s*\#\s*CAPER\s+docker\s(.+)'
     RE_WDL_COMMENT_SINGULARITY = r'^\s*\#\s*CAPER\s+singularity\s(.+)'
-    WDL_WORKFLOW_META_DOCKER = 'caper_docker'
-    WDL_WORKFLOW_META_SINGULARITY = 'caper_singularity'
+    WDL_WORKFLOW_META_DOCKER = ('default_docker', 'caper_docker')
+    WDL_WORKFLOW_META_SINGULARITY = ('default_singularity', 'caper_singularity')
+    WDL_WORKFLOW_META_CONDA = (
+        'default_conda',
+        'default_conda_env',
+        'caper_conda',
+        'caper_conda_env',
+    )
 
     def __init__(self, wdl):
         super().__init__(wdl)
 
     @property
     def caper_docker(self):
-        """Find a Docker image in WDL for Caper.
+        """Find a default Docker image in WDL for Caper.
 
         Backward compatibililty:
             Keep using old regex method
             if WDL_WORKFLOW_META_DOCKER doesn't exist in workflow's meta
         """
         if self.workflow_meta:
-            if CaperWDLParser.WDL_WORKFLOW_META_DOCKER in self.workflow_meta:
-                return self.workflow_meta[CaperWDLParser.WDL_WORKFLOW_META_DOCKER]
+            for docker_key in CaperWDLParser.WDL_WORKFLOW_META_DOCKER:
+                if docker_key in self.workflow_meta:
+                    return self.workflow_meta[docker_key]
 
         ret = self._find_val_of_matched_lines(CaperWDLParser.RE_WDL_COMMENT_DOCKER)
         if ret:
@@ -35,16 +42,26 @@ class CaperWDLParser(WDLParser):
 
     @property
     def caper_singularity(self):
-        """Find a Singularity image in WDL for Caper.
+        """Find a default Singularity image in WDL for Caper.
 
         Backward compatibililty:
             Keep using old regex method
             if WDL_WORKFLOW_META_SINGULARITY doesn't exist in workflow's meta
         """
         if self.workflow_meta:
-            if CaperWDLParser.WDL_WORKFLOW_META_SINGULARITY in self.workflow_meta:
-                return self.workflow_meta[CaperWDLParser.WDL_WORKFLOW_META_SINGULARITY]
+            for singularity_key in CaperWDLParser.WDL_WORKFLOW_META_SINGULARITY:
+                if singularity_key in self.workflow_meta:
+                    return self.workflow_meta[singularity_key]
 
         ret = self._find_val_of_matched_lines(CaperWDLParser.RE_WDL_COMMENT_SINGULARITY)
         if ret:
             return ret[0].strip('"\'')
+
+    @property
+    def caper_conda(self):
+        """Find a default Conda environment name in WDL for Caper.
+        """
+        if self.workflow_meta:
+            for conda_key in CaperWDLParser.WDL_WORKFLOW_META_CONDA:
+                if conda_key in self.workflow_meta:
+                    return self.workflow_meta[conda_key]

--- a/caper/caper_workflow_opts.py
+++ b/caper/caper_workflow_opts.py
@@ -6,9 +6,15 @@ import os
 from autouri import GCSURI, AutoURI
 
 from .caper_wdl_parser import CaperWDLParser
-from .cromwell_backend import BACKEND_AWS, BACKEND_GCP
+from .cromwell_backend import (
+    BACKEND_AWS,
+    BACKEND_GCP,
+    ENVIRONMENT_CONDA,
+    ENVIRONMENT_DOCKER,
+    ENVIRONMENT_SINGULARITY,
+)
 from .dict_tool import merge_dict
-from .singularity import Singularity
+from .singularity import find_bindpath
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +40,8 @@ class CaperWorkflowOpts:
         sge_extra_param=None,
         pbs_queue=None,
         pbs_extra_param=None,
+        lsf_queue=None,
+        lsf_extra_param=None,
     ):
         """Template for a workflows options JSON file.
         All parameters are optional.
@@ -76,6 +84,13 @@ class CaperWorkflowOpts:
                 For pbs backend only.
                 Extra parameters for PBS.
                 This will be appended to "qsub" command line.
+            lsf_queue:
+                For lsf backend only.
+                LSF queue to submit tasks to.
+            lsf_extra_param:
+                For lsf backend only.
+                Extra parameters for LSF.
+                This will be appended to "bsub" command line.
         """
         self._template = {CaperWorkflowOpts.DEFAULT_RUNTIME_ATTRIBUTES: dict()}
         dra = self._template[CaperWorkflowOpts.DEFAULT_RUNTIME_ATTRIBUTES]
@@ -102,6 +117,11 @@ class CaperWorkflowOpts:
         if pbs_extra_param:
             dra['pbs_extra_param'] = pbs_extra_param
 
+        if lsf_queue:
+            dra['lsf_queue'] = lsf_queue
+        if lsf_extra_param:
+            dra['lsf_extra_param'] = lsf_extra_param
+
     def create_file(
         self,
         directory,
@@ -111,8 +131,7 @@ class CaperWorkflowOpts:
         custom_options=None,
         docker=None,
         singularity=None,
-        singularity_cachedir=None,
-        no_build_singularity=False,
+        conda=None,
         max_retries=DEFAULT_MAX_RETRIES,
         memory_retry_multiplier=DEFAULT_MEMORY_RETRY_MULTIPLIER,
         gcp_monitoring_script=DEFAULT_GCP_MONITORING_SCRIPT,
@@ -146,21 +165,12 @@ class CaperWorkflowOpts:
                 This will be merged at the end of this function.
                 Therefore, users can override on Caper's auto-generated
                 workflow options JSON file.
+            conda:
+                Default Conda environemnt name to run a workflow.
             docker:
-                Docker image to run a workflow on.
+                Default Docker image to run a workflow on.
             singularity:
-                Singularity image to run a workflow on.
-            singularity_cachedir:
-                Singularity cache directory to build local images on.
-                This will be overriden by environment variable SINGULARITY_CACHEDIR.
-            no_build_singularity:
-                Caper run "singularity exec IMAGE" to build a local Singularity image
-                before submitting/running a workflow.
-                With this flag on, Caper does not pre-build a local Singularity container.
-                Therefore, Singularity container will be built inside each task,
-                which will result in multiple redundant local image building.
-                Also, trying to build on the same Singularity image file can
-                lead to corruption of the image file.
+                Default Singularity image to run a workflow on.
             max_retries:
                 Maximum number of retirals for each task. 1 means 1 retrial.
             memory_retry_multiplier:
@@ -183,55 +193,93 @@ class CaperWorkflowOpts:
             template['backend'] = backend
 
         wdl_parser = CaperWDLParser(wdl)
+
+        # sanity check for environment flags
+        defined_env_flags = [env for env in (docker, singularity, conda) if env]
+        if len(defined_env_flags) > 1:
+            raise ValueError(
+                'docker, singularity and conda are mutually exclusive. '
+                'Define nothing or only one environment.'
+            )
+
+        if docker is not None:
+            environment = ENVIRONMENT_DOCKER
+        elif singularity is not None:
+            environment = ENVIRONMENT_SINGULARITY
+        elif conda is not None:
+            environment = ENVIRONMENT_CONDA
+        else:
+            environment = None
+
+        if environment:
+            dra['environment'] = environment
+
         if docker == '' or backend in (BACKEND_GCP, BACKEND_AWS) and not docker:
-            # find "caper-docker" from WDL's workflow.meta
-            # or "#CAPER docker" from comments
-            docker = wdl_parser.caper_docker
+            # if used as a flag or cloud backend is chosen
+            # try to find "default_docker" from WDL's workflow.meta or "#CAPER docker" from comments
+            docker = wdl_parser.default_docker
             if docker:
                 logger.info(
-                    'Docker image found in WDL\'s metadata. wdl={wdl}, d={d}'.format(
+                    'Docker image found in WDL metadata. wdl={wdl}, d={d}'.format(
                         wdl=wdl, d=docker
                     )
                 )
             else:
-                logger.warning(
-                    "Docker image not found in WDL's metadata, which means that "
-                    "docker is not defined either as comment (#CAPER docker) or "
-                    "in workflow's meta section (under key caper_docker) in WDL. "
-                    "If your WDL already has docker defined "
-                    "in each task's runtime "
-                    "then it should be okay. wdl={wdl}".format(wdl=wdl)
+                logger.info(
+                    "Docker image not found in WDL metadata. wdl={wdl}".format(wdl=wdl)
                 )
+
         if docker:
             dra['docker'] = docker
 
         if singularity == '':
+            # if used as a flag
             if backend in (BACKEND_GCP, BACKEND_AWS):
                 raise ValueError(
                     'Singularity cannot be used for cloud backend (e.g. aws, gcp).'
                 )
 
-            singularity = wdl_parser.caper_singularity
+            singularity = wdl_parser.default_singularity
             if singularity:
                 logger.info(
-                    'Singularity image found in WDL\'s metadata. wdl={wdl}, s={s}'.format(
+                    'Singularity image found in WDL metadata. wdl={wdl}, s={s}'.format(
                         wdl=wdl, s=singularity
                     )
                 )
             else:
-                raise ValueError(
-                    'Singularity image not found in WDL. wdl={wdl}'.format(wdl=wdl)
+                logger.info(
+                    'Singularity image not found in WDL metadata. wdl={wdl}.'.format(
+                        wdl=wdl
+                    )
                 )
+
         if singularity:
             dra['singularity'] = singularity
-            if singularity_cachedir:
-                dra['singularity_cachedir'] = singularity_cachedir
-
-            s = Singularity(singularity, singularity_cachedir)
             if inputs:
-                dra['singularity_bindpath'] = s.find_bindpath(inputs)
-            if not no_build_singularity:
-                s.build_local_image()
+                dra['singularity_bindpath'] = find_bindpath(inputs)
+
+        if conda == '':
+            # if used as a flag
+            if backend in (BACKEND_GCP, BACKEND_AWS):
+                raise ValueError(
+                    'Conda cannot be used for cloud backend (e.g. aws, gcp).'
+                )
+            conda = wdl_parser.default_conda
+            if conda:
+                logger.info(
+                    'Conda environment name found in WDL metadata. wdl={wdl}, s={s}'.format(
+                        wdl=wdl, s=conda
+                    )
+                )
+            else:
+                logger.info(
+                    'Conda environment name not found in WDL metadata. wdl={wdl}'.format(
+                        wdl=wdl
+                    )
+                )
+
+        if conda:
+            dra['conda'] = conda
 
         if max_retries is not None:
             dra['maxRetries'] = max_retries

--- a/caper/cromwell_backend.py
+++ b/caper/cromwell_backend.py
@@ -16,7 +16,12 @@ BACKEND_ALIAS_LOCAL = 'local'
 BACKEND_SLURM = 'slurm'
 BACKEND_SGE = 'sge'
 BACKEND_PBS = 'pbs'
+BACKEND_LSF = 'lsf'
 DEFAULT_BACKEND = BACKEND_LOCAL
+
+ENVIRONMENT_DOCKER = 'docker'
+ENVIRONMENT_SINGULARITY = 'singularity'
+ENVIRONMENT_CONDA = 'conda'
 
 FILESYSTEM_GCS = 'gcs'
 FILESYSTEM_LOCAL = 'local'
@@ -286,7 +291,7 @@ class CromwellBackendBase(UserDict):
         return self.backend_config['default-runtime-attributes']
 
 
-class CromwellBackendGCP(CromwellBackendBase):
+class CromwellBackendGcp(CromwellBackendBase):
     TEMPLATE = {'google': {'application-name': 'cromwell'}}
     TEMPLATE_BACKEND = {
         'config': {
@@ -352,8 +357,8 @@ class CromwellBackendGCP(CromwellBackendBase):
             filesystem_name=FILESYSTEM_GCS,
             call_caching_dup_strat=call_caching_dup_strat,
         )
-        merge_dict(self.data, CromwellBackendGCP.TEMPLATE)
-        self.merge_backend(CromwellBackendGCP.TEMPLATE_BACKEND)
+        merge_dict(self.data, CromwellBackendGcp.TEMPLATE)
+        self.merge_backend(CromwellBackendGcp.TEMPLATE_BACKEND)
 
         config = self.backend_config
         genomics = config['genomics']
@@ -381,12 +386,12 @@ class CromwellBackendGCP(CromwellBackendBase):
             ]
 
         if use_google_cloud_life_sciences:
-            self.backend['actor-factory'] = CromwellBackendGCP.ACTOR_FACTORY_V2BETA
-            genomics['endpoint-url'] = CromwellBackendGCP.GENOMICS_ENDPOINT_V2BETA
+            self.backend['actor-factory'] = CromwellBackendGcp.ACTOR_FACTORY_V2BETA
+            genomics['endpoint-url'] = CromwellBackendGcp.GENOMICS_ENDPOINT_V2BETA
             genomics['location'] = gcp_region
         else:
-            self.backend['actor-factory'] = CromwellBackendGCP.ACTOR_FACTORY_V2ALPHA
-            genomics['endpoint-url'] = CromwellBackendGCP.GENOMICS_ENDPOINT_V2ALPHA
+            self.backend['actor-factory'] = CromwellBackendGcp.ACTOR_FACTORY_V2ALPHA
+            genomics['endpoint-url'] = CromwellBackendGcp.GENOMICS_ENDPOINT_V2ALPHA
             if gcp_zones:
                 self.default_runtime_attributes['zones'] = ' '.join(gcp_zones)
 
@@ -399,7 +404,7 @@ class CromwellBackendGCP(CromwellBackendBase):
         config['root'] = gcp_out_dir
 
 
-class CromwellBackendAWS(CromwellBackendBase):
+class CromwellBackendAws(CromwellBackendBase):
     TEMPLATE = {
         'aws': {
             'application-name': 'cromwell',
@@ -456,8 +461,8 @@ class CromwellBackendAWS(CromwellBackendBase):
             filesystem_name=FILESYSTEM_S3,
             call_caching_dup_strat=call_caching_dup_strat,
         )
-        merge_dict(self.data, CromwellBackendAWS.TEMPLATE)
-        self.merge_backend(CromwellBackendAWS.TEMPLATE_BACKEND)
+        merge_dict(self.data, CromwellBackendAws.TEMPLATE)
+        self.merge_backend(CromwellBackendAws.TEMPLATE_BACKEND)
 
         aws = self[BACKEND_AWS]
         aws['region'] = aws_region
@@ -476,10 +481,140 @@ class CromwellBackendAWS(CromwellBackendBase):
 
 class CromwellBackendLocal(CromwellBackendBase):
     """Class constants:
-        MAKE_CMD_SUBMIT:
-            Includes BASH command line for Singularity.
+
+        SUBMIT_DOCKER_PATH_REMAP_FOR_CONDA:
+            These shell script contents will be prepended to 'submit-docker' (docker version of 'submit')
+            when Conda is used.
+
+            Cromwell falls back to 'submit_docker' instead of 'submit' if WDL task has
+            'docker' in runtime.
+            Docker and Singularity can map paths between in and out of the container on their own.
+            So this is not an issue for those container environments. But Conda cannot.
+
+            For Conda, any container paths (/cromwell-executions/**) in the script is simply
+            replaced with CWD.
+
+            This also replaces filenames written in write_*.tsv files (grabbed by WDL functions).
+            e.g. write_lines(), write_tsv(), ...
+
+            See the following for such WDL functions:
+            https://github.com/openwdl/wdl/blob/main/versions/development/SPEC.md#file-write_linesarraystring
+
+            Possible issue:
+            - 'sed' is used here with a delimiter as hash mark (#)
+              so hash marks in output path can result in error.
+            - Files grabbed by WDL functions other than write_*() will still have container paths.
+
     """
 
+    RUNTIME_ATTRIBUTES = dedent(
+        """
+        ## Caper custom attributes
+        # Environment choices = (docker, conda, singularity)
+        # If environment is not specified then prioritize docker > singularity > conda
+        # gpu is a plain string (to be able to specify gpu's name)
+        String? environment
+        String? conda
+        String? singularity
+        String? singularity_bindpath
+        String? gpu
+
+        ## Cromwell built-in attributes
+        String? docker
+        String? docker_user
+    """
+    )
+    SUBMIT = dedent(
+        """
+        if [ '${defined(environment)}' == 'true' ] && [ '${environment}' == 'singularity' ] || \\
+           [ '${defined(environment)}' == 'false' ] && [ '${defined(singularity)}' == 'true' ] && [ ! -z '${singularity}' ]
+        then
+            mkdir -p $HOME/.singularity/lock/
+            flock --exclusive --timeout 600 \\
+                $HOME/.singularity/lock/`echo -n '${singularity}' | md5sum | cut -d' ' -f1` \\
+                singularity exec --containall ${singularity} echo 'Successfully pulled ${singularity}'
+
+            singularity exec --cleanenv --home=${cwd} --bind=${singularity_bindpath}, \\
+              ${if defined(gpu) then ' --nv' else ''} \\
+              ${singularity} ${job_shell} ${script}
+
+        elif [ '${defined(environment)}' == 'true' ] && [ '${environment}' == 'conda' ] || \\
+             [ '${defined(environment)}' == 'false' ] && [ '${defined(conda)}' == 'true' ] && [ ! -z '${conda}' ]
+        then
+            conda run --name=${conda} ${job_shell} ${script}
+
+        else
+            ${job_shell} ${script}
+        fi
+    """
+    )
+    SUBMIT_DOCKER = dedent(
+        """
+        rm -f ${docker_cid}
+
+        if [ '${defined(environment)}' == 'true' ] && [ '${environment}' == 'docker' ] || \\
+           [ '${defined(environment)}' == 'false' ] && [ '${defined(docker)}' == 'true' ] && [ ! -z '${docker}' ]
+        then
+            docker run -i --cidfile=${docker_cid} --user=${docker_user} --entrypoint=${job_shell} \\
+              --volume=${cwd}:${docker_cwd}:delegated ${docker} ${docker_script}
+            rc=$(docker wait `cat ${docker_cid}`)
+            docker rm `cat ${docker_cid}`
+
+        elif [ '${defined(environment)}' == 'true' ] && [ '${environment}' == 'singularity' ] || \\
+             [ '${defined(environment)}' == 'false' ] && [ '${defined(singularity)}' == 'true' ] && [ ! -z '${singularity}' ]
+        then
+            mkdir -p $HOME/.singularity/lock/
+            flock --exclusive --timeout 600 \\
+                $HOME/.singularity/lock/`echo -n '${singularity}' | md5sum | cut -d' ' -f1` \\
+                singularity exec --containall ${singularity} echo 'Successfully pulled ${singularity}'
+
+            singularity exec --cleanenv --home=${cwd} --bind=${singularity_bindpath},${cwd}:${docker_cwd} \\
+              ${if defined(gpu) then ' --nv' else ''} \\
+              ${singularity} ${job_shell} ${script} & echo $! > ${docker_cid}
+            touch ${docker_cid}.not_docker
+            wait `cat ${docker_cid}`
+            rc=`echo $?`
+
+        elif [ '${defined(environment)}' == 'true' ] && [ '${environment}' == 'conda' ] || \\
+             [ '${defined(environment)}' == 'false' ] && [ '${defined(conda)}' == 'true' ] && [ ! -z '${conda}' ]
+        then
+            conda run --name=${conda} ${job_shell} ${script} & echo $! > ${docker_cid}
+            touch ${docker_cid}.not_docker
+            wait `cat ${docker_cid}`
+            rc=`echo $?`
+
+        else
+            ${job_shell} ${script} & echo $! > ${docker_cid}
+            touch ${docker_cid}.not_docker
+            wait `cat ${docker_cid}`
+            rc=`echo $?`
+        fi
+
+        exit $rc
+    """
+    )
+    KILL_DOCKER = dedent(
+        """
+        if [ -f '${docker_cid}.not_docker' ]
+        then
+            kill `cat ${docker_cid}`
+        else
+            docker kill `cat ${docker_cid}`
+        fi
+    """
+    )
+    SUBMIT_DOCKER_PATH_REMAP_FOR_CONDA = dedent(
+        """
+        if [ '${defined(environment)}' == 'true' ] && [ '${environment}' == 'conda' ] || \\
+             [ '${defined(environment)}' == 'false' ] && [ '${defined(conda)}' == 'true' ] && [ ! -z '${conda}' ]
+        then
+            for file_to_remap_path in ${script} `dirname ${script}`/write_*.tmp
+            do
+                sed -i 's#${docker_cwd}#${cwd}#g' $file_to_remap_path
+            done
+        fi
+    """
+    )
     TEMPLATE_BACKEND = {
         'actor-factory': 'cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory',
         'config': {
@@ -495,40 +630,12 @@ class CromwellBackendLocal(CromwellBackendBase):
                 }
             },
             'run-in-background': True,
-            'runtime-attributes': dedent(
-                """\
-                Int? gpu
-                String? docker
-                String? docker_user
-                String? singularity
-                String? singularity_bindpath
-                String? singularity_cachedir
-                """
+            'runtime-attributes': RUNTIME_ATTRIBUTES,
+            'submit': SUBMIT,
+            'submit-docker': '\n'.join(
+                [SUBMIT_DOCKER_PATH_REMAP_FOR_CONDA, SUBMIT_DOCKER]
             ),
-            'submit': dedent(
-                """\
-                if [ -z \\"$SINGULARITY_BINDPATH\\" ]; then export SINGULARITY_BINDPATH=${singularity_bindpath}; fi; \\
-                if [ -z \\"$SINGULARITY_CACHEDIR\\" ]; then export SINGULARITY_CACHEDIR=${singularity_cachedir}; fi;
-                ${if !defined(singularity) then '/bin/bash ' + script
-                  else
-                    'singularity exec --cleanenv ' +
-                    '--home ' + cwd + ' ' +
-                    (if defined(gpu) then '--nv ' else '') +
-                    singularity + ' /bin/bash ' + script}
-            """
-            ),
-            'submit-docker': dedent(
-                """\
-                rm -f ${docker_cid}
-                docker run \\
-                  --cidfile ${docker_cid} \\
-                  -i \\
-                  ${'--user ' + docker_user} \\
-                  --entrypoint ${job_shell} \\
-                  -v ${cwd}:${docker_cwd} \\
-                  ${docker} ${docker_script}
-                """
-            ),
+            'kill-docker': KILL_DOCKER,
         },
     }
 
@@ -542,6 +649,13 @@ class CromwellBackendLocal(CromwellBackendBase):
         local_hash_strat=DEFAULT_LOCAL_HASH_STRAT,
         max_concurrent_tasks=CromwellBackendBase.DEFAULT_CONCURRENT_JOB_LIMIT,
     ):
+        """Base class for local backends.
+
+        Used flock to synchronize local Singularity image building.
+        Image building will occur in the first task and other parallel tasks will wait.
+
+        See https://github.com/broadinstitute/cromwell/issues/5063 for details.
+        """
         super().__init__(
             backend_name=backend_name,
             max_concurrent_tasks=max_concurrent_tasks,
@@ -571,84 +685,151 @@ class CromwellBackendLocal(CromwellBackendBase):
         config['root'] = local_out_dir
 
 
-class CromwellBackendSLURM(CromwellBackendLocal):
-    """SLURM backend.
-    Try sbatching up to 3 times every 30 second.
-    Some busy SLURM clusters spit out error, which results in a failure of the whole workflow
-
-    Squeues every 30 second (up to 3 times)
-    Unlike qstat -j JOB_ID, squeue -j JOB_ID doesn't return 1 when there is no such job
-    So we need to use squeue -j JOB_ID --noheader and check if output is empty
-    Try polling up to 3 times since squeue fails on some busy SLURM clusters
-    e.g. on Stanford Sherlock, squeue didn't work when server is busy
+class CromwellBackendHpc(CromwellBackendLocal):
+    HPC_RUNTIME_ATTRIBUTES = dedent(
+        """
+        Int cpu = 1
+        Int? time
+        Int? memory_mb
     """
+    )
 
-    TEMPLATE_BACKEND = {
-        'config': {
-            'default-runtime-attributes': {'time': 24},
-            'exit-code-timeout-seconds': 360,
-            'runtime-attributes': dedent(
-                """\
-                String? docker
-                String? docker_user
-                Int cpu = 1
-                Int? gpu
-                Int? time
-                Int? memory_mb
-                String? slurm_partition
-                String? slurm_account
-                String? slurm_extra_param
-                String? singularity
-                String? singularity_bindpath
-                String? singularity_cachedir
-            """
-            ),
-            'submit': dedent(
-                """\
-                if [ -z \\"$SINGULARITY_BINDPATH\\" ]; then export SINGULARITY_BINDPATH=${singularity_bindpath}; fi; \\
-                if [ -z \\"$SINGULARITY_CACHEDIR\\" ]; then export SINGULARITY_CACHEDIR=${singularity_cachedir}; fi;
+    def __init__(
+        self,
+        local_out_dir,
+        backend_name=None,
+        max_concurrent_tasks=CromwellBackendBase.DEFAULT_CONCURRENT_JOB_LIMIT,
+        soft_glob_output=False,
+        local_hash_strat=CromwellBackendLocal.DEFAULT_LOCAL_HASH_STRAT,
+        check_alive=None,
+        kill=None,
+        job_id_regex=None,
+        submit=None,
+        submit_docker=None,
+        runtime_attributes=None,
+    ):
+        """Base class for HPCs.
 
-                ITER=0
-                until [ $ITER -ge 3 ]; do
-                    sbatch \\
-                        --export=ALL \\
-                        -J ${job_name} \\
-                        -D ${cwd} \\
-                        -o ${out} \\
-                        -e ${err} \\
-                        ${'-t ' + time*60} \\
-                        -n 1 \\
-                        --ntasks-per-node=1 \\
-                        ${'--cpus-per-task=' + cpu} \\
-                        ${true="--mem=" false="" defined(memory_mb)}${memory_mb} \\
-                        ${'-p ' + slurm_partition} \\
-                        ${'--account ' + slurm_account} \\
-                        ${'--gres gpu:' + gpu} \\
-                        ${slurm_extra_param} \\
-                        --wrap "${if !defined(singularity) then '/bin/bash ' + script
-                                  else
-                                    'singularity exec --cleanenv ' +
-                                    '--home ' + cwd + ' ' +
-                                    (if defined(gpu) then '--nv ' else '') +
-                                    singularity + ' /bin/bash ' + script}" \\
-                        && break
-                    ITER=$[$ITER+1]
+        Args:
+            check_alive:
+                Shell command lines to check if a job exists.
+                WDL syntax allowed in ${} notation.
+            kill:
+                Shell command lines to kill a job.
+                WDL syntax allowed in ${} notation.
+                This will be passed to both 'kill' and 'kill-docker'.
+                On HPCs jobs are managed in terms of job ID (not PID).
+            job_id_regex:
+                Regular expression to find job ID.
+                Make sure to escape backslash (\\) since this is directly used in a shell script.
+                WDL syntax NOT allowed.
+            submit:
+                Shell command lines to submit a job.
+                WDL syntax allowed in ${} notation.
+            submit_docker:
+                Shell command lines to submit a job
+                (when docker is defined in WDL task's runtime).
+                WDL syntax allowed in ${} notation.
+            runtime_attributes:
+                Declaration of WDL variables (attributes) used in submit, submit-docker.
+                This is not a shell command line but plain WDL syntax.
+                Make sure that non-Cromwell variables (attributes) used in submit, submit-docker
+                are defined here.
+                e.g. cpu, memory, docker, docker_user are Cromwell's built-in variables
+                so they don't need to be defined but slurm_partition, sge_pe are
+                Caper's custom variables so such variables should be defined there.
+        """
+        super().__init__(
+            local_out_dir=local_out_dir,
+            backend_name=backend_name,
+            max_concurrent_tasks=max_concurrent_tasks,
+            soft_glob_output=soft_glob_output,
+            local_hash_strat=local_hash_strat,
+        )
+        config = self.backend_config
+
+        if not check_alive:
+            raise ValueError('check_alive not defined!')
+        if not kill:
+            raise ValueError('kill not defined!')
+        if not job_id_regex:
+            raise ValueError('job_id_regex not defined!')
+        if not submit:
+            raise ValueError('submit not defined!')
+
+        config['check-alive'] = check_alive
+        config['kill'] = kill
+        # jobs are managed based on job ID (not PID) on HPCs
+        # docker version of kill will not be different
+        config['kill-docker'] = kill
+        config['job-id-regex'] = job_id_regex
+        config['submit'] = submit
+        config['submit-docker'] = submit_docker
+        config['runtime-attributes'] = '\n'.join(
+            [
+                CromwellBackendLocal.RUNTIME_ATTRIBUTES,
+                CromwellBackendHpc.HPC_RUNTIME_ATTRIBUTES,
+                runtime_attributes if runtime_attributes else '',
+            ]
+        )
+
+
+class CromwellBackendSlurm(CromwellBackendHpc):
+    SLURM_RUNTIME_ATTRIBUTES = dedent(
+        """
+        String? slurm_partition
+        String? slurm_account
+        String? slurm_extra_param
+    """
+    )
+    SLURM_CHECK_ALIVE = dedent(
+        """
+        for ITER in 1 2 3; do
+            CHK_ALIVE=$(squeue --noheader -j ${job_id} --format=%i | grep ${job_id})
+            if [ -z "$CHK_ALIVE" ]
+            then
+                if [ "$ITER" == 3 ]
+                then
+                    ${job_shell} -c 'exit 1'
+                else
                     sleep 30
-                done
-            """
-            ),
-            'check-alive': dedent(
-                """\
-                for ITER in 1 2 3; do
-                    CHK_ALIVE=$(squeue --noheader -j ${job_id} --format=%i | grep ${job_id})
-                    if [ -z "$CHK_ALIVE" ]; then if [ "$ITER" == 3 ]; then /bin/bash -c 'exit 1'; else sleep 30; fi; else echo $CHK_ALIVE; break; fi
-                done
-            """
-            ),
-            'kill': 'scancel ${job_id}',
-            'job-id-regex': 'Submitted batch job (\\d+).*',
-        }
-    }
+                fi
+            else
+                echo $CHK_ALIVE
+                break
+            fi
+        done
+    """
+    )
+    SLURM_KILL = 'scancel ${job_id}'
+    SLURM_JOB_ID_REGEX = 'Submitted batch job (\\d+).*'
+
+    # this is a template that requires formatting
+    # (submit_docker_path_remap_for_conda, submit, slurm_resource_param)
+    TEMPLATE_SLURM_SUBMIT = dedent(
+        """
+        cat << EOF > ${{script}}.caper
+        #!/bin/bash
+        {submit_docker_path_remap_for_conda}
+        {submit}
+        EOF
+
+        for ITER in 1 2 3; do
+            sbatch --export=ALL -J ${{job_name}} -D ${{cwd}} -o ${{out}} -e ${{err}} \\
+                ${{'-p ' + slurm_partition}} ${{'--account ' + slurm_account}} \\
+                {slurm_resource_param} \\
+                ${{slurm_extra_param}} \\
+                ${{script}}.caper && break
+            sleep 30
+        done
+    """
+    )
+    DEFAULT_SLURM_RESOURCE_PARAM = (
+        '-n 1 --ntasks-per-node=1 --cpus-per-task=${cpu} '
+        '${if defined(memory_mb) then "--mem=" else ""}${memory_mb}${if defined(memory_mb) then "M" else ""} '
+        '${if defined(time) then "--time=" else ""}${time*60} '
+        '${if defined(gpu) then "--gres=gpu:" else ""}${gpu} '
+    )
 
     def __init__(
         self,
@@ -659,16 +840,51 @@ class CromwellBackendSLURM(CromwellBackendLocal):
         slurm_partition=None,
         slurm_account=None,
         slurm_extra_param=None,
+        slurm_resource_param=DEFAULT_SLURM_RESOURCE_PARAM,
     ):
+        """SLURM backend.
+        Try sbatching up to 3 times every 30 second to prevent Cromwell
+        from halting the whole pipeline immediately after the first failure.
+
+        Example busy server errors:
+            slurm_load_jobs error: Socket timed out on send/recv operation
+            slurm_load_jobs error: Slurm backup controller in standby mode
+
+        Squeues every 30 second up to 3 times for the same reason.
+        Unlike qstat -j JOB_ID, squeue -j JOB_ID doesn't return 1 when there is no such job
+        So 'squeue --noheader -j JOB_ID' is used here and it checks if output is empty
+
+        Args:
+            slurm_resource_param:
+                String of a set of resource parameters for the job submission engine.
+                WDL syntax allowed in ${} notation.
+                This will be appended to the job sumbission command line.
+                e.g. sbatch ... THIS_RESOURCE_PARAM
+        """
+        submit = CromwellBackendSlurm.TEMPLATE_SLURM_SUBMIT.format(
+            submit_docker_path_remap_for_conda='',
+            submit=CromwellBackendLocal.SUBMIT,
+            slurm_resource_param=slurm_resource_param,
+        )
+        submit_docker = CromwellBackendSlurm.TEMPLATE_SLURM_SUBMIT.format(
+            submit_docker_path_remap_for_conda=CromwellBackendLocal.SUBMIT_DOCKER_PATH_REMAP_FOR_CONDA,
+            submit=CromwellBackendLocal.SUBMIT,
+            slurm_resource_param=slurm_resource_param,
+        )
+
         super().__init__(
             local_out_dir=local_out_dir,
             backend_name=BACKEND_SLURM,
             max_concurrent_tasks=max_concurrent_tasks,
             soft_glob_output=soft_glob_output,
             local_hash_strat=local_hash_strat,
+            check_alive=CromwellBackendSlurm.SLURM_CHECK_ALIVE,
+            kill=CromwellBackendSlurm.SLURM_KILL,
+            job_id_regex=CromwellBackendSlurm.SLURM_JOB_ID_REGEX,
+            submit=submit,
+            submit_docker=submit_docker,
+            runtime_attributes=CromwellBackendSlurm.SLURM_RUNTIME_ATTRIBUTES,
         )
-        self.merge_backend(CromwellBackendSLURM.TEMPLATE_BACKEND)
-        self.backend_config.pop('submit-docker')
 
         if slurm_partition:
             self.default_runtime_attributes['slurm_partition'] = slurm_partition
@@ -678,63 +894,47 @@ class CromwellBackendSLURM(CromwellBackendLocal):
             self.default_runtime_attributes['slurm_extra_param'] = slurm_extra_param
 
 
-class CromwellBackendSGE(CromwellBackendLocal):
-    TEMPLATE_BACKEND = {
-        'config': {
-            'default-runtime-attributes': {'time': 24},
-            'exit-code-timeout-seconds': 180,
-            'runtime-attributes': dedent(
-                """\
-                String? docker
-                String? docker_user
-                String sge_pe = "shm"
-                Int cpu = 1
-                Int? gpu
-                Int? time
-                Int? memory_mb
-                String? sge_queue
-                String? sge_extra_param
-                String? singularity
-                String? singularity_bindpath
-                String? singularity_cachedir
-            """
-            ),
-            'submit': dedent(
-                """\
-                if [ -z \\"$SINGULARITY_BINDPATH\\" ]; then export SINGULARITY_BINDPATH=${singularity_bindpath}; fi; \\
-                if [ -z \\"$SINGULARITY_CACHEDIR\\" ]; then export SINGULARITY_CACHEDIR=${singularity_cachedir}; fi;
+class CromwellBackendSge(CromwellBackendHpc):
+    SGE_RUNTIME_ATTRIBUTES = dedent(
+        """
+        String? sge_pe
+        String? sge_queue
+        String? sge_extra_param
+    """
+    )
+    SGE_CHECK_ALIVE = 'qstat -j ${job_id}'
+    SGE_KILL = 'qdel ${job_id}'
 
-                echo "${if !defined(singularity) then '/bin/bash ' + script
-                        else
-                          'singularity exec --cleanenv ' +
-                          '--home ' + cwd + ' ' +
-                          (if defined(gpu) then '--nv ' else '') +
-                          singularity + ' /bin/bash ' + script}" | \\
-                qsub \\
-                    -S /bin/sh \\
-                    -terse \\
-                    -b n \\
-                    -N ${job_name} \\
-                    -wd ${cwd} \\
-                    -o ${out} \\
-                    -e ${err} \\
-                    ${if cpu>1 then '-pe ' + sge_pe + ' ' else ''} \\
-                    ${if cpu>1 then cpu else ''} \\
-                    ${true="-l h_vmem=$(expr " false="" defined(memory_mb)}${memory_mb}${true=" / " false="" defined(memory_mb)}${if defined(memory_mb) then cpu else ""}${true=")m" false="" defined(memory_mb)} \\
-                    ${true="-l s_vmem=$(expr " false="" defined(memory_mb)}${memory_mb}${true=" / " false="" defined(memory_mb)}${if defined(memory_mb) then cpu else ""}${true=")m" false="" defined(memory_mb)} \\
-                    ${'-l h_rt=' + time + ':00:00'} \\
-                    ${'-l s_rt=' + time + ':00:00'} \\
-                    ${'-q ' + sge_queue} \\
-                    ${'-l gpu=' + gpu} \\
-                    ${sge_extra_param} \\
-                    -V
-            """
-            ),
-            'check-alive': 'qstat -j ${job_id}',
-            'kill': 'qdel ${job_id}',
-            'job-id-regex': '(\\d+)',
-        }
-    }
+    # qsub -terse is used to simply this regex
+    SGE_JOB_ID_REGEX = '(\\d+)'
+
+    # this is a template that requires formatting
+    # (submit_docker_path_remap_for_conda, submit, sge_resource_param)
+    TEMPLATE_SGE_SUBMIT = dedent(
+        """
+        cat << EOF > ${{script}}.caper
+        #!/bin/bash
+        {submit_docker_path_remap_for_conda}
+        {submit}
+        EOF
+
+        for ITER in 1 2 3; do
+            qsub -V -terse -S ${{job_shell}} -N ${{job_name}} -wd ${{cwd}} -o ${{out}} -e ${{err}} \\
+                ${{'-q ' + sge_queue}} \\
+                {sge_resource_param} \\
+                ${{sge_extra_param}} \\
+                ${{script}}.caper && break
+            sleep 30
+        done
+    """
+    )
+    DEFAULT_SGE_RESOURCE_PARAM = (
+        '${if cpu > 1 then "-pe " + sge_pe + " " else ""} ${if cpu > 1 then cpu else ""} '
+        '${true="-l h_vmem=$(expr " false="" defined(memory_mb)}${memory_mb}${true=" / " false="" defined(memory_mb)}${if defined(memory_mb) then cpu else ""}${true=")m" false="" defined(memory_mb)} '
+        '${true="-l s_vmem=$(expr " false="" defined(memory_mb)}${memory_mb}${true=" / " false="" defined(memory_mb)}${if defined(memory_mb) then cpu else ""}${true=")m" false="" defined(memory_mb)} '
+        '${"-l h_rt=" + time + ":00:00"} ${"-l s_rt=" + time + ":00:00"} '
+        '${"-l gpu=" + gpu} '
+    )
 
     def __init__(
         self,
@@ -745,16 +945,41 @@ class CromwellBackendSGE(CromwellBackendLocal):
         sge_pe=None,
         sge_queue=None,
         sge_extra_param=None,
+        sge_resource_param=DEFAULT_SGE_RESOURCE_PARAM,
     ):
+        """SGE backend. Try qsubbing up to 3 times every 30 second.
+
+        Args:
+            sge_resource_param:
+                String of a set of resource parameters for the job submission engine.
+                WDL syntax allowed in ${} notation.
+                This will be appended to the job sumbission command line.
+                e.g. qsub ... THIS_RESOURCE_PARAM
+        """
+        submit = CromwellBackendSge.TEMPLATE_SGE_SUBMIT.format(
+            submit_docker_path_remap_for_conda='',
+            submit=CromwellBackendLocal.SUBMIT,
+            sge_resource_param=sge_resource_param,
+        )
+        submit_docker = CromwellBackendSge.TEMPLATE_SGE_SUBMIT.format(
+            submit_docker_path_remap_for_conda=CromwellBackendLocal.SUBMIT_DOCKER_PATH_REMAP_FOR_CONDA,
+            submit=CromwellBackendLocal.SUBMIT,
+            sge_resource_param=sge_resource_param,
+        )
+
         super().__init__(
             local_out_dir=local_out_dir,
             backend_name=BACKEND_SGE,
             max_concurrent_tasks=max_concurrent_tasks,
             soft_glob_output=soft_glob_output,
             local_hash_strat=local_hash_strat,
+            check_alive=CromwellBackendSge.SGE_CHECK_ALIVE,
+            kill=CromwellBackendSge.SGE_KILL,
+            job_id_regex=CromwellBackendSge.SGE_JOB_ID_REGEX,
+            submit=submit,
+            submit_docker=submit_docker,
+            runtime_attributes=CromwellBackendSge.SGE_RUNTIME_ATTRIBUTES,
         )
-        self.merge_backend(CromwellBackendSGE.TEMPLATE_BACKEND)
-        self.backend_config.pop('submit-docker')
 
         if sge_pe:
             self.default_runtime_attributes['sge_pe'] = sge_pe
@@ -764,55 +989,42 @@ class CromwellBackendSGE(CromwellBackendLocal):
             self.default_runtime_attributes['sge_extra_param'] = sge_extra_param
 
 
-class CromwellBackendPBS(CromwellBackendLocal):
-    TEMPLATE_BACKEND = {
-        'config': {
-            'default-runtime-attributes': {'time': 24},
-            'script-epilogue': 'sleep 5',
-            'runtime-attributes': dedent(
-                """\
-                String? docker
-                String? docker_user
-                Int cpu = 1
-                Int? gpu
-                Int? time
-                Int? memory_mb
-                String? pbs_queue
-                String? pbs_extra_param
-                String? singularity
-                String? singularity_bindpath
-                String? singularity_cachedir
-            """
-            ),
-            'submit': dedent(
-                """\
-                if [ -z \\"$SINGULARITY_BINDPATH\\" ]; then export SINGULARITY_BINDPATH=${singularity_bindpath}; fi; \\
-                if [ -z \\"$SINGULARITY_CACHEDIR\\" ]; then export SINGULARITY_CACHEDIR=${singularity_cachedir}; fi;
+class CromwellBackendPbs(CromwellBackendHpc):
+    PBS_RUNTIME_ATTRIBUTES = dedent(
+        """
+        String? pbs_queue
+        String? pbs_extra_param
+    """
+    )
+    PBS_CHECK_ALIVE = 'qstat ${job_id}'
+    PBS_KILL = 'qdel ${job_id}'
+    PBS_JOB_ID_REGEX = '(\\d+)'
 
-                echo "${if !defined(singularity) then '/bin/bash ' + script
-                        else
-                          'singularity exec --cleanenv ' +
-                          '--home ' + cwd + ' ' +
-                          (if defined(gpu) then '--nv ' else '') +
-                          singularity + ' /bin/bash ' + script}" | \\
-                qsub \\
-                    -N ${job_name} \\
-                    -o ${out} \\
-                    -e ${err} \\
-                    ${true="-lnodes=1:ppn=" false="" defined(cpu)}${cpu}${true=":mem=" false="" defined(memory_mb)}${memory_mb}${true="mb" false="" defined(memory_mb)} \\
-                    ${'-lwalltime=' + time + ':0:0'} \\
-                    ${'-lngpus=' + gpu} \\
-                    ${'-q ' + pbs_queue} \\
-                    ${pbs_extra_param} \\
-                    -V
-            """
-            ),
-            'exit-code-timeout-seconds': 180,
-            'kill': 'qdel ${job_id}',
-            'check-alive': 'qstat ${job_id}',
-            'job-id-regex': '(\\d+)',
-        }
-    }
+    # this is a template that requires formatting
+    # (submit_docker_path_remap_for_conda, submit, pbs_resource_param)
+    TEMPLATE_PBS_SUBMIT = dedent(
+        """
+        cat << EOF > ${{script}}.caper
+        #!/bin/bash
+        {submit_docker_path_remap_for_conda}
+        {submit}
+        EOF
+
+        for ITER in 1 2 3; do
+            qsub -V -N ${{job_name}} -o ${{out}} -e ${{err}} \\
+                ${{'-q ' + pbs_queue}} \\
+                {pbs_resource_param} \\
+                ${{pbs_extra_param}} \\
+                ${{script}}.caper && break
+            sleep 30
+        done
+    """
+    )
+    DEFAULT_PBS_RESOURCE_PARAM = (
+        '${"-lnodes=1:ppn=" + cpu}${if defined(gpu) then ":gpus=" + gpu else ""} '
+        '${if defined(memory_mb) then "-l mem=" else ""}${memory_mb}${if defined(memory_mb) then "mb" else ""} '
+        '${"-lwalltime=" + time + ":0:0"} '
+    )
 
     def __init__(
         self,
@@ -822,18 +1034,131 @@ class CromwellBackendPBS(CromwellBackendLocal):
         local_hash_strat=CromwellBackendLocal.DEFAULT_LOCAL_HASH_STRAT,
         pbs_queue=None,
         pbs_extra_param=None,
+        pbs_resource_param=DEFAULT_PBS_RESOURCE_PARAM,
     ):
+        """PBS backend. Try qsubbing up to 3 times every 30 second.
+
+        Args:
+            pbs_resource_param:
+                String of a set of resource parameters for the job submission engine.
+                WDL syntax allowed in ${} notation.
+                This will be appended to the job sumbission command line.
+                e.g. qsub ... THIS_RESOURCE_PARAM
+        """
+        submit = CromwellBackendPbs.TEMPLATE_PBS_SUBMIT.format(
+            submit_docker_path_remap_for_conda='',
+            submit=CromwellBackendLocal.SUBMIT,
+            pbs_resource_param=pbs_resource_param,
+        )
+        submit_docker = CromwellBackendPbs.TEMPLATE_PBS_SUBMIT.format(
+            submit_docker_path_remap_for_conda=CromwellBackendLocal.SUBMIT_DOCKER_PATH_REMAP_FOR_CONDA,
+            submit=CromwellBackendLocal.SUBMIT,
+            pbs_resource_param=pbs_resource_param,
+        )
+
         super().__init__(
             local_out_dir=local_out_dir,
             backend_name=BACKEND_PBS,
             max_concurrent_tasks=max_concurrent_tasks,
             soft_glob_output=soft_glob_output,
             local_hash_strat=local_hash_strat,
+            check_alive=CromwellBackendPbs.PBS_CHECK_ALIVE,
+            kill=CromwellBackendPbs.PBS_KILL,
+            job_id_regex=CromwellBackendPbs.PBS_JOB_ID_REGEX,
+            submit=submit,
+            submit_docker=submit_docker,
+            runtime_attributes=CromwellBackendPbs.PBS_RUNTIME_ATTRIBUTES,
         )
-        self.merge_backend(CromwellBackendPBS.TEMPLATE_BACKEND)
-        self.backend_config.pop('submit-docker')
 
         if pbs_queue:
             self.default_runtime_attributes['pbs_queue'] = pbs_queue
         if pbs_extra_param:
             self.default_runtime_attributes['pbs_extra_param'] = pbs_extra_param
+
+
+class CromwellBackendLsf(CromwellBackendHpc):
+    LSF_RUNTIME_ATTRIBUTES = dedent(
+        """
+        String? lsf_queue
+        String? lsf_extra_param
+    """
+    )
+    LSF_CHECK_ALIVE = 'bjobs ${job_id}'
+    LSF_KILL = 'bkill ${job_id}'
+    LSF_JOB_ID_REGEX = 'Job <(\\d+)>.*'
+
+    # this is a template that requires formatting
+    # (submit_docker_path_remap_for_conda, submit, lsf_resource_param)
+    TEMPLATE_LSF_SUBMIT = dedent(
+        """
+        cat << EOF > ${{script}}.caper
+        #!/bin/bash
+        {submit_docker_path_remap_for_conda}
+        {submit}
+        EOF
+
+        for ITER in 1 2 3; do
+            bsub -env "all" -J ${{job_name}} -cwd ${{cwd}} -o ${{out}} -e ${{err}} \\
+                ${{'-q ' + lsf_queue}} \\
+                {lsf_resource_param} \\
+                ${{lsf_extra_param}} \\
+                ${{job_shell}} ${{script}}.caper && break
+            sleep 30
+        done
+    """
+    )
+    DEFAULT_LSF_RESOURCE_PARAM = (
+        '${"-n " + cpu} '
+        '${if defined(gpu) then "-gpu " + gpu else ""} '
+        '${if defined(memory_mb) then "-M " else ""}${memory_mb}${if defined(memory_mb) then "m" else ""} '
+        '${"-W " + 60*time} '
+    )
+
+    def __init__(
+        self,
+        local_out_dir,
+        max_concurrent_tasks=CromwellBackendBase.DEFAULT_CONCURRENT_JOB_LIMIT,
+        soft_glob_output=False,
+        local_hash_strat=CromwellBackendLocal.DEFAULT_LOCAL_HASH_STRAT,
+        lsf_queue=None,
+        lsf_extra_param=None,
+        lsf_resource_param=DEFAULT_LSF_RESOURCE_PARAM,
+    ):
+        """LSF backend. Try bsubbing up to 3 times every 30 second.
+
+        Args:
+            lsf_resource_param:
+                String of a set of resource parameters for the job submission engine.
+                WDL syntax allowed in ${} notation.
+                This will be appended to the job sumbission command line.
+                e.g. qsub ... THIS_RESOURCE_PARAM
+        """
+        submit = CromwellBackendLsf.TEMPLATE_LSF_SUBMIT.format(
+            submit_docker_path_remap_for_conda='',
+            submit=CromwellBackendLocal.SUBMIT,
+            lsf_resource_param=lsf_resource_param,
+        )
+        submit_docker = CromwellBackendLsf.TEMPLATE_LSF_SUBMIT.format(
+            submit_docker_path_remap_for_conda=CromwellBackendLocal.SUBMIT_DOCKER_PATH_REMAP_FOR_CONDA,
+            submit=CromwellBackendLocal.SUBMIT,
+            lsf_resource_param=lsf_resource_param,
+        )
+
+        super().__init__(
+            local_out_dir=local_out_dir,
+            backend_name=BACKEND_LSF,
+            max_concurrent_tasks=max_concurrent_tasks,
+            soft_glob_output=soft_glob_output,
+            local_hash_strat=local_hash_strat,
+            check_alive=CromwellBackendLsf.LSF_CHECK_ALIVE,
+            kill=CromwellBackendLsf.LSF_KILL,
+            job_id_regex=CromwellBackendLsf.LSF_JOB_ID_REGEX,
+            submit=submit,
+            submit_docker=submit_docker,
+            runtime_attributes=CromwellBackendLsf.LSF_RUNTIME_ATTRIBUTES,
+        )
+
+        if lsf_queue:
+            self.default_runtime_attributes['lsf_queue'] = lsf_queue
+        if lsf_extra_param:
+            self.default_runtime_attributes['lsf_extra_param'] = lsf_extra_param

--- a/caper/singularity.py
+++ b/caper/singularity.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from subprocess import check_call
 
 from autouri import AbsPath, AutoURI, URIBase
 from autouri.loc_aux import recurse_json
@@ -8,119 +7,72 @@ from autouri.loc_aux import recurse_json
 logger = logging.getLogger(__name__)
 
 
-class Singularity:
-    DEFAULT_SINGULARITY_CACHEDIR = '~/.caper/singularity_cachedir'
-    DEFAULT_COMMON_ROOT_SEARCH_LEVEL = 5
+DEFAULT_COMMON_ROOT_SEARCH_LEVEL = 5
 
-    def __init__(
-        self, singularity_image, singularity_cachedir=DEFAULT_SINGULARITY_CACHEDIR
-    ):
-        """This class is based on Singularity CLI.
-        """
-        self._singularity_image = singularity_image
-        self._singularity_cachedir = singularity_cachedir
 
-    def build_local_image(self):
-        """Build local image for Singularity on SINGULARITY_CACHEDIR.
+def find_bindpath(json_file, common_root_search_level=DEFAULT_COMMON_ROOT_SEARCH_LEVEL):
+    """Recursively find paths to be bound for singularity.
+    Find common roots for all files in an input JSON file.
+    This function will recursively visit all values in input JSON and
+    also JSON, TSV, CSV files in the input JSON itself.
 
-        Args.
-            singularity_cachedir:
-                Cache directory for local Singularity images.
-                If there is a shell environment variable SINGULARITY_CACHEDIR
-                define then this parameter will be ignored.
-        """
-        singularity_cachedir = os.path.abspath(
-            os.path.expanduser(self._singularity_cachedir)
-        )
-        os.makedirs(singularity_cachedir, exist_ok=True)
+    This function visit all files in input JSON.
+    Files with some extensions (defined by Autouri's URIBase.LOC_RECURSE_EXT_AND_FNC)
+    are recursively visited.
 
-        cmd = [
-            'singularity',
-            'exec',
-            self._singularity_image,
-            'echo',
-            'Built local singularity image for {img}'.format(
-                img=self._singularity_image
-            ),
-        ]
-        logger.info(
-            'Building local singularity image for {img}'.format(
-                img=self._singularity_image
-            )
-        )
+    Add all (but not too high level<4) parent directories
+    to all_dirnames. start from original
+    For example, we have /a/b/c/d/e/f/g/h with common_root_search_level = 5
+        add all the followings:
+        /a/b/c/d/e/f/g/h (org)
+        /a/b/c/d/e/f/g
+        /a/b/c/d/e/f
+        /a/b/c/d/e
+        /a/b/c/d (minimum level = COMMON_ROOT_SEARCH_LEVEL-1)
 
-        env = os.environ.copy()
-        if self._singularity_cachedir and 'SINGULARITY_CACHEDIR' not in env:
-            env['SINGULARITY_CACHEDIR'] = self._singularity_cachedir
+    Args:
+        json_file:
+            Input JSON file which have local paths in it.
+            Non-path values will be just ignored.
+        common_root_search_level:
+            See above description.
+    """
+    json_contents = AutoURI(json_file).read()
+    all_dirnames = []
 
-        return check_call(cmd, env=env)
+    def find_dirname(s):
+        u = AbsPath(s)
+        if u.is_valid:
+            for ext, recurse_fnc_for_ext in URIBase.LOC_RECURSE_EXT_AND_FNC.items():
+                if u.ext == ext:
+                    _, _ = recurse_fnc_for_ext(u.read(), find_dirname)
+            # file can be a soft-link
+            # singularity will want to have access to both soft-link and real one
+            # so add dirnames of both soft-link and realpath
+            all_dirnames.append(u.dirname)
+            all_dirnames.append(os.path.dirname(os.path.realpath(u.uri)))
+        return None, False
 
-    @staticmethod
-    def find_bindpath(
-        json_file, common_root_search_level=DEFAULT_COMMON_ROOT_SEARCH_LEVEL
-    ):
-        """Recursively find paths to be bound for singularity.
-        Find common roots for all files in an input JSON file.
-        This function will recursively visit all values in input JSON and
-        also JSON, TSV, CSV files in the input JSON itself.
+    _, _ = recurse_json(json_contents, find_dirname)
 
-        This function visit all files in input JSON.
-        Files with some extensions (defined by Autouri's URIBase.LOC_RECURSE_EXT_AND_FNC)
-        are recursively visited.
+    all_dnames_incl_parents = set(all_dirnames)
+    for d in all_dirnames:
+        dir_arr = d.split(os.sep)
+        for i, _ in enumerate(dir_arr[common_root_search_level:]):
+            d_child = os.sep.join(dir_arr[: i + common_root_search_level])
+            all_dnames_incl_parents.add(d_child)
 
-        Add all (but not too high level<4) parent directories
-        to all_dirnames. start from original
-        For example, we have /a/b/c/d/e/f/g/h with common_root_search_level = 5
-            add all the followings:
-            /a/b/c/d/e/f/g/h (org)
-            /a/b/c/d/e/f/g
-            /a/b/c/d/e/f
-            /a/b/c/d/e
-            /a/b/c/d (minimum level = COMMON_ROOT_SEARCH_LEVEL-1)
+    bindpaths = set()
+    # remove overlapping directories
+    for i, d1 in enumerate(sorted(all_dnames_incl_parents, reverse=True)):
+        overlap_found = False
+        for j, d2 in enumerate(sorted(all_dnames_incl_parents, reverse=True)):
+            if i >= j:
+                continue
+            if d1.startswith(d2):
+                overlap_found = True
+                break
+        if not overlap_found:
+            bindpaths.add(d1)
 
-        Args:
-            json_file:
-                Input JSON file which have local paths in it.
-                Non-path values will be just ignored.
-            common_root_search_level:
-                See above description.
-        """
-        json_contents = AutoURI(json_file).read()
-        all_dirnames = []
-
-        def find_dirname(s):
-            u = AbsPath(s)
-            if u.is_valid:
-                for ext, recurse_fnc_for_ext in URIBase.LOC_RECURSE_EXT_AND_FNC.items():
-                    if u.ext == ext:
-                        _, _ = recurse_fnc_for_ext(u.read(), find_dirname)
-                # file can be a soft-link
-                # singularity will want to have access to both soft-link and real one
-                # so add dirnames of both soft-link and realpath
-                all_dirnames.append(u.dirname)
-                all_dirnames.append(os.path.dirname(os.path.realpath(u.uri)))
-            return None, False
-
-        _, _ = recurse_json(json_contents, find_dirname)
-
-        all_dnames_incl_parents = set(all_dirnames)
-        for d in all_dirnames:
-            dir_arr = d.split(os.sep)
-            for i, _ in enumerate(dir_arr[common_root_search_level:]):
-                d_child = os.sep.join(dir_arr[: i + common_root_search_level])
-                all_dnames_incl_parents.add(d_child)
-
-        bindpaths = set()
-        # remove overlapping directories
-        for i, d1 in enumerate(sorted(all_dnames_incl_parents, reverse=True)):
-            overlap_found = False
-            for j, d2 in enumerate(sorted(all_dnames_incl_parents, reverse=True)):
-                if i >= j:
-                    continue
-                if d1.startswith(d2):
-                    overlap_found = True
-                    break
-            if not overlap_found:
-                bindpaths.add(d1)
-
-        return ','.join(bindpaths)
+    return ','.join(bindpaths)

--- a/tests/test_singularity.py
+++ b/tests/test_singularity.py
@@ -1,8 +1,7 @@
 import json
-import os
 from textwrap import dedent
 
-from caper.singularity import Singularity
+from caper.singularity import find_bindpath
 
 UBUNTU_18_04_3 = (
     'ubuntu@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90'
@@ -10,26 +9,6 @@ UBUNTU_18_04_3 = (
 UBUNTU_18_04_3_LAST_HASH_TAR_GZ = (
     'sha256:6001e1789921cf851f6fb2e5fe05be70f482fe9c2286f66892fe5a3bc404569c.tar.gz'
 )
-
-
-def test_build_local_image(tmp_path):
-    """Singularity class works with Singularity CLI.
-    Make sure to have such CLI installed on your system.
-
-    Make sure to unset env var SINGULARITY_CACHEDIR before running pytest.
-
-    This test will build a local Singularity image, which is consist of
-    multiple docker layer (hash) files (tar.gz).
-    This test will check one of the hashes.
-    """
-    singularity = Singularity(
-        singularity_image='docker://' + UBUNTU_18_04_3,
-        singularity_cachedir=str(tmp_path),
-    )
-    singularity.build_local_image()
-
-    hash_file = str(tmp_path / 'docker' / UBUNTU_18_04_3_LAST_HASH_TAR_GZ)
-    assert os.path.exists(hash_file)
 
 
 def test_find_bindpath(tmp_path):
@@ -40,7 +19,7 @@ def test_find_bindpath(tmp_path):
     in docker).
 
     Input JSON file has one TSV file and this file will be recursively visited by
-    Singularilty.find_bindpath().
+    find_bindpath().
     """
     tsv = tmp_path / 'test.tsv'
     tsv_contents = dedent(
@@ -63,7 +42,7 @@ def test_find_bindpath(tmp_path):
     inputs.write_text(json.dumps(inputs_dict, indent=4))
 
     # test with two different levels
-    bindpaths_5 = Singularity.find_bindpath(str(inputs), 5).split(',')
+    bindpaths_5 = find_bindpath(str(inputs), 5).split(',')
     assert sorted(bindpaths_5) == sorted(
         [
             '/1/2/3',
@@ -76,7 +55,7 @@ def test_find_bindpath(tmp_path):
         ]
     )
 
-    bindpaths_2 = Singularity.find_bindpath(str(inputs), 2).split(',')
+    bindpaths_2 = find_bindpath(str(inputs), 2).split(',')
     assert sorted(bindpaths_2) == sorted(
         ['/1', '/a', '/f', '/s', '/'.join(str(tmp_path).split('/')[:2])]
     )


### PR DESCRIPTION
Refactoring for local backends (slurm, sge, pbs, lsf)
- Added LSF backend
- Better/robust implementation of base local backend
  - Can work with `conda`, `singularity` in task's `runtime`
  - Can run conda, singularity even when `docker` exists in `runtime`.
  - No need to activate Conda environment (internall runs `conda -n ENV_NAME COMMANDS`)