### PR TITLE
Pip 1640 fix gid issue

### DIFF
--- a/caper/__init__.py
+++ b/caper/__init__.py
@@ -2,4 +2,4 @@ from .caper_client import CaperClient, CaperClientSubmit
 from .caper_runner import CaperRunner
 
 __all__ = ['CaperClient', 'CaperClientSubmit', 'CaperRunner']
-__version__ = '2.0.0'
+__version__ = '2.1.0'

--- a/caper/caper_args.py
+++ b/caper/caper_args.py
@@ -148,7 +148,9 @@ def get_parser_and_defaults(conf_file=None):
         '--cromwell-stdout',
         default=DEFAULT_CROMWELL_STDOUT,
         help='Local file to write STDOUT of Cromwell Java process to. '
-        'This is for Cromwell (not for Caper\'s logging system).',
+        'This is for Cromwell (not for Caper\'s logging system). '
+        'If this file already exists then Caper will make a new file suffixed with '
+        'incremented index. e.g. cromwell.out.1 ',
     )
     group_db = parent_runner.add_argument_group(
         title='General DB settings (for both file DB and MySQL DB)'

--- a/caper/caper_init.py
+++ b/caper/caper_init.py
@@ -154,7 +154,7 @@ slurm-partition=
 
 # IMPORTANT warning for Stanford Sherlock cluster
 # ====================================================================
-# DO NOT install any codes/executables
+# DO NOT install any codes/executables/Miniconda
 # (java, conda, python, caper, pipeline's WDL, pipeline's Conda env, ...) on $SCRATCH or $OAK.
 # You will see Segmentation Fault errors.
 # Install all executables on $HOME or $PI_HOME instead.
@@ -173,6 +173,16 @@ backend=slurm
 
 # SLURM account. Define only if required by a cluster. You must define it for Stanford SCG.
 slurm-account=
+
+# IMPORTANT warning for Stanford SCG cluster
+# ====================================================================
+# DO NOT install any codes/executables/Miniconda
+# (java, conda, python, caper, pipeline's WDL, pipeline's Conda env, ...) on your home (/home/$USER).
+# Pipelines will get stuck due to slow filesystem.
+# ALSO DO NOT USE /local/scratch to run pipelines. This directory is not static.
+# Use $OAK storage to run pipelines, and to store codes/WDLs/executables.
+# ====================================================================
+
 """
     + CONF_CONTENTS_SLURM_PARAM
     + CONF_CONTENTS_LOCAL_HASH_STRAT

--- a/caper/cli.py
+++ b/caper/cli.py
@@ -57,6 +57,15 @@ def get_abspath(path):
     return path
 
 
+def check_local_file_and_rename_if_exists(path, index=0):
+    org_path = path
+    if index:
+        path = '.'.join([path, str(index)])
+    if os.path.exists(path):
+        return check_local_file_and_rename_if_exists(org_path, index + 1)
+    return path
+
+
 def print_version(parser, args):
     if args.version:
         print(version)
@@ -341,7 +350,11 @@ def subcmd_server(caper_runner, args, nonblocking=False):
     if nonblocking:
         return caper_runner.server(fileobj_stdout=sys.stdout, **args_from_cli)
 
-    cromwell_stdout = get_abspath(args.cromwell_stdout)
+    cromwell_stdout = check_local_file_and_rename_if_exists(
+        get_abspath(args.cromwell_stdout)
+    )
+    logger.info('Cromwell stdout: {stdout}'.format(stdout=cromwell_stdout))
+
     with open(cromwell_stdout, 'w') as f:
         try:
             thread = caper_runner.server(fileobj_stdout=f, **args_from_cli)
@@ -356,7 +369,10 @@ def subcmd_server(caper_runner, args, nonblocking=False):
 
 
 def subcmd_run(caper_runner, args):
-    cromwell_stdout = get_abspath(args.cromwell_stdout)
+    cromwell_stdout = check_local_file_and_rename_if_exists(
+        get_abspath(args.cromwell_stdout)
+    )
+    logger.info('Cromwell stdout: {stdout}'.format(stdout=cromwell_stdout))
 
     with open(cromwell_stdout, 'w') as f:
         try:


### PR DESCRIPTION
Fix all docker-related issues on HPC backends
- `docker` attribute in WDL task's `runtime` is now safely ignored.
- removed all adhoc workarounds to bypass `docker`.
- Fix for https://github.com/ENCODE-DCC/caper/issues/149

Make a new Cromwell STDOUT out if exists (e.g. `cromwell.out.1`)

Use workflow's root directory (instead of call's root) for Singularity `--home` directory.
- to include soft-linked `inputs` files from other calls into the scope of a Singularity container.
